### PR TITLE
feat: implement Phase 1 core Discord transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
 # dakopi
+
+Discord transport plugin for [takopi](https://github.com/banteg/takopi) - "he just wants to help-pi... on Discord!"
+
+## Concept
+
+Maps Discord's structure to takopi's project/branch/session model:
+
+| Discord | Takopi | Purpose |
+|---------|--------|---------|
+| Category | Project | Repository context |
+| Channel | Branch | Feature branch / worktree |
+| Thread | Session | Conversation with agent |
+
+## Structure Example
+
+```
+FURTHERMORE (category)
+├── #main
+├── #issue-764-remove-ybgt
+├── #issue-840-vault-search
+└── Voice: furthermore-vc
+
+TAKOPI (category)
+├── #main
+├── #feat
+└── Voice: takopi-vc
+```
+
+## Installation
+
+```bash
+# Install dakopi
+pip install dakopi
+
+# Or with uv
+uv pip install dakopi
+
+# Verify the transport is loaded
+takopi plugins --load
+```
+
+## Configuration
+
+```toml
+# takopi.toml
+transport = "discord"
+
+[transports.discord]
+bot_token = "..."
+guild_id = 123456789  # optional, for single-guild mode
+message_overflow = "trim"  # or "split"
+session_mode = "stateless"  # or "chat"
+```
+
+## Setup
+
+1. Create a Discord application at https://discord.com/developers/applications
+2. Create a bot and copy the token
+3. Enable "Message Content Intent" under Privileged Gateway Intents
+4. Run `takopi setup` and follow the prompts
+5. Invite the bot to your server using the generated URL
+
+## Slash Commands
+
+- `/status` - Show current channel context and status
+- `/bind <project>` - Bind channel to a project
+- `/unbind` - Remove project binding
+- `/cancel` - Cancel running task
+
+## Discord Bot Permissions Required
+
+- Read Messages / View Channels
+- Send Messages
+- Create Public Threads
+- Send Messages in Threads
+- Manage Threads
+- Read Message History
+- Add Reactions
+- Attach Files
+- Use Slash Commands
+
+## Development
+
+```bash
+# Clone the repo
+git clone https://github.com/asianviking/takopi-discord.git
+cd takopi-discord
+
+# Install in development mode
+uv pip install -e .
+
+# Run tests
+pytest
+```
+
+## License
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "dakopi"
+authors = [{name = "ayvee"}]
+version = "0.1.0"
+description = "Discord transport plugin for takopi"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.14"
+dependencies = [
+    "discord.py>=2.5.0",
+    "takopi>=0.17.0",
+]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3 :: Only",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/asianviking/takopi-discord"
+Repository = "https://github.com/asianviking/takopi-discord"
+Issues = "https://github.com/asianviking/takopi-discord/issues"
+
+[project.entry-points."takopi.transport_backends"]
+discord = "dakopi.backend:BACKEND"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dakopi"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.0",
+    "pytest-anyio>=0.0.0",
+    "ruff>=0.14.0",
+]
+
+[tool.ruff.lint]
+extend-select = ["B", "BLE001", "C4", "PERF", "SIM", "UP"]

--- a/src/dakopi/__init__.py
+++ b/src/dakopi/__init__.py
@@ -1,0 +1,9 @@
+"""Discord transport plugin for takopi."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .backend import BACKEND
+
+__all__ = ["BACKEND", "__version__"]

--- a/src/dakopi/backend.py
+++ b/src/dakopi/backend.py
@@ -1,0 +1,148 @@
+"""Discord transport backend for takopi."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from takopi.backends import EngineBackend
+from takopi.logging import get_logger
+from takopi.runner_bridge import ExecBridgeConfig
+from takopi.transport_runtime import TransportRuntime
+from takopi.transports import SetupResult, TransportBackend
+
+from .bridge import DiscordBridgeConfig, DiscordPresenter, DiscordTransport
+from .client import DiscordBotClient
+from .loop import run_main_loop
+from .onboarding import check_setup, interactive_setup
+
+logger = get_logger(__name__)
+
+__all__ = ["BACKEND", "DiscordBackend"]
+
+
+def _get_discord_settings(transport_config: object) -> dict[str, Any]:
+    """Extract Discord settings from transport config.
+
+    Since Discord is a plugin, settings come as a dict from model_extra.
+    """
+    if isinstance(transport_config, dict):
+        return transport_config
+    # Try to convert pydantic model to dict
+    if hasattr(transport_config, "model_dump"):
+        return transport_config.model_dump()
+    raise TypeError(f"unexpected transport_config type: {type(transport_config)}")
+
+
+def _build_startup_message(
+    runtime: TransportRuntime,
+    *,
+    startup_pwd: str,
+) -> str:
+    """Build the startup message displayed when bot connects."""
+    available_engines = list(runtime.available_engine_ids())
+    missing_engines = list(runtime.missing_engine_ids())
+    misconfigured_engines = list(runtime.engine_ids_with_status("bad_config"))
+    failed_engines = list(runtime.engine_ids_with_status("load_error"))
+
+    engine_list = ", ".join(available_engines) if available_engines else "none"
+
+    notes: list[str] = []
+    if missing_engines:
+        notes.append(f"not installed: {', '.join(missing_engines)}")
+    if misconfigured_engines:
+        notes.append(f"misconfigured: {', '.join(misconfigured_engines)}")
+    if failed_engines:
+        notes.append(f"failed to load: {', '.join(failed_engines)}")
+    if notes:
+        engine_list = f"{engine_list} ({'; '.join(notes)})"
+
+    project_aliases = sorted(set(runtime.project_aliases()), key=str.lower)
+    project_list = ", ".join(project_aliases) if project_aliases else "none"
+
+    return (
+        f"\N{OCTOPUS} **dakopi is ready**\n\n"
+        f"default: `{runtime.default_engine}`  \n"
+        f"agents: `{engine_list}`  \n"
+        f"projects: `{project_list}`  \n"
+        f"working in: `{startup_pwd}`"
+    )
+
+
+class DiscordBackend(TransportBackend):
+    """Discord transport backend implementation."""
+
+    id = "discord"
+    description = "Discord bot"
+
+    def check_setup(
+        self,
+        engine_backend: EngineBackend,
+        *,
+        transport_override: str | None = None,
+    ) -> SetupResult:
+        return check_setup(engine_backend, transport_override=transport_override)
+
+    def interactive_setup(self, *, force: bool) -> bool:
+        return interactive_setup(force=force)
+
+    def lock_token(
+        self, *, transport_config: object, _config_path: Path
+    ) -> str | None:
+        settings = _get_discord_settings(transport_config)
+        return settings.get("bot_token")
+
+    def build_and_run(
+        self,
+        *,
+        transport_config: object,
+        config_path: Path,
+        runtime: TransportRuntime,
+        final_notify: bool,
+        default_engine_override: str | None,
+    ) -> None:
+        settings = _get_discord_settings(transport_config)
+        token = settings["bot_token"]
+        guild_id = settings.get("guild_id")
+        message_overflow = settings.get("message_overflow", "trim")
+        session_mode = settings.get("session_mode", "stateless")
+        show_resume_line = settings.get("show_resume_line", True)
+
+        startup_msg = _build_startup_message(
+            runtime,
+            startup_pwd=os.getcwd(),
+        )
+
+        bot = DiscordBotClient(token, guild_id=guild_id)
+        transport = DiscordTransport(bot)
+        presenter = DiscordPresenter(message_overflow=message_overflow)
+        exec_cfg = ExecBridgeConfig(
+            transport=transport,
+            presenter=presenter,
+            final_notify=final_notify,
+        )
+        cfg = DiscordBridgeConfig(
+            bot=bot,
+            runtime=runtime,
+            guild_id=guild_id,
+            startup_msg=startup_msg,
+            exec_cfg=exec_cfg,
+            session_mode=session_mode,
+            show_resume_line=show_resume_line,
+            message_overflow=message_overflow,
+        )
+
+        async def run_loop() -> None:
+            await run_main_loop(
+                cfg,
+                default_engine_override=default_engine_override,
+            )
+
+        anyio.run(run_loop)
+
+
+discord_backend = DiscordBackend()
+BACKEND = discord_backend

--- a/src/dakopi/bridge.py
+++ b/src/dakopi/bridge.py
@@ -1,0 +1,285 @@
+"""Discord transport and presenter implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, cast
+
+import discord
+
+from takopi.markdown import MarkdownFormatter
+from takopi.progress import ProgressState
+from takopi.transport import MessageRef, RenderedMessage, SendOptions
+
+from .client import DiscordBotClient
+from .render import MAX_BODY_CHARS, prepare_discord, prepare_discord_multi
+
+if TYPE_CHECKING:
+    from takopi.runner_bridge import ExecBridgeConfig
+    from takopi.transport_runtime import TransportRuntime
+
+__all__ = [
+    "DiscordBridgeConfig",
+    "DiscordPresenter",
+    "DiscordTransport",
+]
+
+CANCEL_BUTTON_ID = "dakopi:cancel"
+
+
+class CancelView(discord.ui.View):
+    """View with cancel button."""
+
+    def __init__(self, *, on_cancel: callable | None = None) -> None:
+        super().__init__(timeout=None)
+        self._on_cancel = on_cancel
+
+    @discord.ui.button(label="cancel", style=discord.ButtonStyle.secondary, custom_id=CANCEL_BUTTON_ID)
+    async def cancel_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        if self._on_cancel is not None:
+            await self._on_cancel(interaction)
+        else:
+            await interaction.response.defer()
+
+
+class ClearView(discord.ui.View):
+    """Empty view to clear buttons."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+
+class DiscordPresenter:
+    """Presenter for rendering messages to Discord format."""
+
+    def __init__(
+        self,
+        *,
+        formatter: MarkdownFormatter | None = None,
+        message_overflow: str = "trim",
+    ) -> None:
+        self._formatter = formatter or MarkdownFormatter()
+        self._message_overflow = message_overflow
+
+    def render_progress(
+        self,
+        state: ProgressState,
+        *,
+        elapsed_s: float,
+        label: str = "working",
+    ) -> RenderedMessage:
+        """Render a progress update message."""
+        parts = self._formatter.render_progress_parts(
+            state, elapsed_s=elapsed_s, label=label
+        )
+        text = prepare_discord(parts)
+        is_cancelled = _is_cancelled_label(label)
+        return RenderedMessage(
+            text=text,
+            extra={
+                "show_cancel": not is_cancelled,
+            },
+        )
+
+    def render_final(
+        self,
+        state: ProgressState,
+        *,
+        elapsed_s: float,
+        status: str,
+        answer: str,
+    ) -> RenderedMessage:
+        """Render a final response message."""
+        parts = self._formatter.render_final_parts(
+            state, elapsed_s=elapsed_s, status=status, answer=answer
+        )
+        if self._message_overflow == "split":
+            messages = prepare_discord_multi(parts, max_body_chars=MAX_BODY_CHARS)
+            text = messages[0]
+            extra: dict = {"show_cancel": False}
+            if len(messages) > 1:
+                followups = [
+                    RenderedMessage(text=msg, extra={"show_cancel": False})
+                    for msg in messages[1:]
+                ]
+                extra["followups"] = followups
+            return RenderedMessage(text=text, extra=extra)
+        text = prepare_discord(parts)
+        return RenderedMessage(text=text, extra={"show_cancel": False})
+
+
+def _is_cancelled_label(label: str) -> bool:
+    stripped = label.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        stripped = stripped[1:-1]
+    return stripped.lower() == "cancelled"
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordBridgeConfig:
+    """Configuration for the Discord bridge."""
+
+    bot: DiscordBotClient
+    runtime: TransportRuntime
+    guild_id: int | None
+    startup_msg: str
+    exec_cfg: ExecBridgeConfig
+    session_mode: Literal["stateless", "chat"] = "stateless"
+    show_resume_line: bool = True
+    message_overflow: Literal["trim", "split"] = "trim"
+
+
+class DiscordTransport:
+    """Transport implementation for Discord."""
+
+    def __init__(self, bot: DiscordBotClient) -> None:
+        self._bot = bot
+        self._cancel_handlers: dict[int, callable] = {}  # message_id -> handler
+
+    def register_cancel_handler(self, message_id: int, handler: callable) -> None:
+        """Register a cancel handler for a message."""
+        self._cancel_handlers[message_id] = handler
+
+    def unregister_cancel_handler(self, message_id: int) -> None:
+        """Unregister a cancel handler."""
+        self._cancel_handlers.pop(message_id, None)
+
+    async def handle_cancel_interaction(self, interaction: discord.Interaction) -> None:
+        """Handle a cancel button interaction."""
+        if interaction.message is None:
+            await interaction.response.defer()
+            return
+        handler = self._cancel_handlers.get(interaction.message.id)
+        if handler is not None:
+            await handler(interaction)
+        else:
+            await interaction.response.defer()
+
+    @staticmethod
+    def _extract_followups(message: RenderedMessage) -> list[RenderedMessage]:
+        followups = message.extra.get("followups")
+        if not isinstance(followups, list):
+            return []
+        return [item for item in followups if isinstance(item, RenderedMessage)]
+
+    async def _send_followups(
+        self,
+        *,
+        channel_id: int,
+        followups: list[RenderedMessage],
+        reply_to_message_id: int | None,
+        thread_id: int | None,
+    ) -> None:
+        for followup in followups:
+            show_cancel = followup.extra.get("show_cancel", False)
+            view = CancelView() if show_cancel else ClearView()
+            await self._bot.send_message(
+                channel_id=channel_id,
+                content=followup.text,
+                reply_to_message_id=reply_to_message_id,
+                thread_id=thread_id,
+                view=view,
+            )
+
+    async def close(self) -> None:
+        """Close the transport."""
+        await self._bot.close()
+
+    async def send(
+        self,
+        *,
+        channel_id: int | str,
+        message: RenderedMessage,
+        options: SendOptions | None = None,
+    ) -> MessageRef | None:
+        """Send a message."""
+        cid = cast(int, channel_id)
+        reply_to_message_id: int | None = None
+        thread_id: int | None = None
+
+        if options is not None:
+            reply_to_message_id = (
+                cast(int, options.reply_to.message_id)
+                if options.reply_to is not None
+                else None
+            )
+            thread_id = (
+                cast(int | None, options.thread_id)
+                if options.thread_id is not None
+                else None
+            )
+
+        show_cancel = message.extra.get("show_cancel", False)
+        view = CancelView() if show_cancel else ClearView()
+
+        followups = self._extract_followups(message)
+        sent = await self._bot.send_message(
+            channel_id=cid,
+            content=message.text,
+            reply_to_message_id=reply_to_message_id,
+            thread_id=thread_id,
+            view=view,
+        )
+        if sent is None:
+            return None
+
+        if followups:
+            await self._send_followups(
+                channel_id=cid,
+                followups=followups,
+                reply_to_message_id=reply_to_message_id,
+                thread_id=thread_id,
+            )
+
+        return MessageRef(
+            channel_id=cid,
+            message_id=sent.message_id,
+            raw=sent,
+            thread_id=thread_id or sent.thread_id,
+        )
+
+    async def edit(
+        self,
+        *,
+        ref: MessageRef,
+        message: RenderedMessage,
+        wait: bool = True,
+    ) -> MessageRef | None:
+        """Edit an existing message."""
+        channel_id = cast(int, ref.channel_id)
+        message_id = cast(int, ref.message_id)
+
+        show_cancel = message.extra.get("show_cancel", False)
+        view = CancelView() if show_cancel else ClearView()
+
+        followups = self._extract_followups(message)
+        edited = await self._bot.edit_message(
+            channel_id=ref.thread_id or channel_id,
+            message_id=message_id,
+            content=message.text,
+            view=view,
+        )
+        if edited is None:
+            return ref if not wait else None
+
+        if followups:
+            await self._send_followups(
+                channel_id=channel_id,
+                followups=followups,
+                reply_to_message_id=None,
+                thread_id=ref.thread_id,
+            )
+
+        return MessageRef(
+            channel_id=channel_id,
+            message_id=edited.message_id,
+            raw=edited,
+            thread_id=ref.thread_id,
+        )
+
+    async def delete(self, *, ref: MessageRef) -> bool:
+        """Delete a message."""
+        return await self._bot.delete_message(
+            channel_id=cast(int, ref.thread_id or ref.channel_id),
+            message_id=cast(int, ref.message_id),
+        )

--- a/src/dakopi/client.py
+++ b/src/dakopi/client.py
@@ -1,0 +1,242 @@
+"""Discord API client wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import discord
+from discord import app_commands
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    MessageHandler = Callable[[discord.Message], Coroutine[Any, Any, None]]
+    InteractionHandler = Callable[[discord.Interaction], Coroutine[Any, Any, None]]
+
+
+@dataclass(frozen=True, slots=True)
+class SentMessage:
+    """Result of sending a message."""
+
+    message_id: int
+    channel_id: int
+    thread_id: int | None = None
+
+
+class DiscordBotClient:
+    """Wrapper around discord.py client for takopi integration."""
+
+    def __init__(self, token: str, *, guild_id: int | None = None) -> None:
+        self._token = token
+        self._guild_id = guild_id
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.guilds = True
+        intents.members = False
+        self._client = discord.Client(intents=intents)
+        self._tree = app_commands.CommandTree(self._client)
+        self._ready_event = asyncio.Event()
+        self._message_handler: MessageHandler | None = None
+        self._interaction_handler: InteractionHandler | None = None
+
+        @self._client.event
+        async def on_ready() -> None:
+            self._ready_event.set()
+
+        @self._client.event
+        async def on_message(message: discord.Message) -> None:
+            if message.author == self._client.user:
+                return
+            if self._message_handler is not None:
+                await self._message_handler(message)
+
+    @property
+    def client(self) -> discord.Client:
+        """Get the underlying discord.py client."""
+        return self._client
+
+    @property
+    def tree(self) -> app_commands.CommandTree:
+        """Get the command tree for slash commands."""
+        return self._tree
+
+    @property
+    def user(self) -> discord.User | None:
+        """Get the bot user."""
+        return self._client.user
+
+    def set_message_handler(self, handler: MessageHandler) -> None:
+        """Set the message handler."""
+        self._message_handler = handler
+
+    def set_interaction_handler(self, handler: InteractionHandler) -> None:
+        """Set the interaction handler for non-command interactions."""
+        self._interaction_handler = handler
+
+    async def start(self) -> None:
+        """Start the bot and wait until ready."""
+        asyncio.create_task(self._client.start(self._token))
+        await self._ready_event.wait()
+        # Sync commands
+        if self._guild_id is not None:
+            guild = discord.Object(id=self._guild_id)
+            self._tree.copy_global_to(guild=guild)
+            await self._tree.sync(guild=guild)
+        else:
+            await self._tree.sync()
+
+    async def close(self) -> None:
+        """Close the bot connection."""
+        await self._client.close()
+
+    async def wait_until_ready(self) -> None:
+        """Wait until the bot is ready."""
+        await self._ready_event.wait()
+
+    async def send_message(
+        self,
+        *,
+        channel_id: int,
+        content: str,
+        reply_to_message_id: int | None = None,
+        thread_id: int | None = None,
+        view: discord.ui.View | None = None,
+        embed: discord.Embed | None = None,
+    ) -> SentMessage | None:
+        """Send a message to a channel."""
+        channel = self._client.get_channel(thread_id or channel_id)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(thread_id or channel_id)
+            except discord.NotFound:
+                return None
+
+        if not isinstance(channel, discord.abc.Messageable):
+            return None
+
+        reference = None
+        if reply_to_message_id is not None:
+            reference = discord.MessageReference(
+                message_id=reply_to_message_id,
+                channel_id=channel_id,
+            )
+
+        try:
+            kwargs: dict[str, Any] = {"content": content}
+            if reference is not None:
+                kwargs["reference"] = reference
+            if view is not None:
+                kwargs["view"] = view
+            if embed is not None:
+                kwargs["embed"] = embed
+
+            message = await channel.send(**kwargs)
+            return SentMessage(
+                message_id=message.id,
+                channel_id=message.channel.id,
+                thread_id=thread_id,
+            )
+        except discord.HTTPException:
+            return None
+
+    async def edit_message(
+        self,
+        *,
+        channel_id: int,
+        message_id: int,
+        content: str,
+        view: discord.ui.View | None = None,
+        embed: discord.Embed | None = None,
+    ) -> SentMessage | None:
+        """Edit an existing message."""
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(channel_id)
+            except discord.NotFound:
+                return None
+
+        if not isinstance(channel, discord.abc.Messageable):
+            return None
+
+        try:
+            message = await channel.fetch_message(message_id)
+            kwargs: dict[str, Any] = {"content": content}
+            if view is not None:
+                kwargs["view"] = view
+            if embed is not None:
+                kwargs["embed"] = embed
+
+            edited = await message.edit(**kwargs)
+            return SentMessage(
+                message_id=edited.id,
+                channel_id=edited.channel.id,
+            )
+        except discord.HTTPException:
+            return None
+
+    async def delete_message(
+        self,
+        *,
+        channel_id: int,
+        message_id: int,
+    ) -> bool:
+        """Delete a message."""
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(channel_id)
+            except discord.NotFound:
+                return False
+
+        if not isinstance(channel, discord.abc.Messageable):
+            return False
+
+        try:
+            message = await channel.fetch_message(message_id)
+            await message.delete()
+            return True
+        except discord.HTTPException:
+            return False
+
+    async def create_thread(
+        self,
+        *,
+        channel_id: int,
+        message_id: int,
+        name: str,
+        auto_archive_duration: int = 1440,  # 24 hours
+    ) -> int | None:
+        """Create a thread from a message."""
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(channel_id)
+            except discord.NotFound:
+                return None
+
+        if not isinstance(channel, discord.TextChannel):
+            return None
+
+        try:
+            message = await channel.fetch_message(message_id)
+            thread = await message.create_thread(
+                name=name,
+                auto_archive_duration=auto_archive_duration,
+            )
+            return thread.id
+        except discord.HTTPException:
+            return None
+
+    def get_guild(self, guild_id: int) -> discord.Guild | None:
+        """Get a guild by ID."""
+        return self._client.get_guild(guild_id)
+
+    def get_channel(self, channel_id: int) -> discord.abc.GuildChannel | None:
+        """Get a channel by ID."""
+        channel = self._client.get_channel(channel_id)
+        if isinstance(channel, discord.abc.GuildChannel):
+            return channel
+        return None

--- a/src/dakopi/handlers.py
+++ b/src/dakopi/handlers.py
@@ -1,0 +1,199 @@
+"""Slash command and message handlers for Discord."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import discord
+from discord import app_commands
+
+if TYPE_CHECKING:
+    from .bridge import DiscordBridgeConfig
+    from .client import DiscordBotClient
+    from .mapping import CategoryChannelMapper
+    from .state import DiscordStateStore
+
+
+def register_slash_commands(
+    bot: DiscordBotClient,
+    *,
+    state_store: DiscordStateStore,
+    mapper: CategoryChannelMapper,
+    get_running_task: callable,
+    cancel_task: callable,
+) -> None:
+    """Register slash commands with the bot."""
+    tree = bot.tree
+
+    @tree.command(name="status", description="Show current channel context and status")
+    async def status_command(interaction: discord.Interaction) -> None:
+        """Show current channel context and running tasks."""
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        channel_id = interaction.channel_id
+        guild_id = interaction.guild.id
+
+        # Get context from state or infer from channel
+        context = await state_store.get_context(guild_id, channel_id)
+        if context is None:
+            mapping = mapper.get_channel_mapping(guild_id, channel_id)
+            if mapping is not None:
+                context = mapper.get_context_from_mapping(mapping)
+
+        if context is None:
+            await interaction.response.send_message(
+                "No context configured for this channel.\n"
+                "Use `/bind <project>` to set up this channel.",
+                ephemeral=True,
+            )
+            return
+
+        # Check for running task
+        running = get_running_task(channel_id)
+        status_line = "idle"
+        if running is not None:
+            status_line = f"running (message #{running})"
+
+        message = (
+            f"**Channel Status**\n"
+            f"- Project: `{context.project}`\n"
+            f"- Branch: `{context.branch}`\n"
+            f"- Status: {status_line}"
+        )
+        await interaction.response.send_message(message, ephemeral=True)
+
+    @tree.command(name="bind", description="Bind this channel to a project")
+    @app_commands.describe(
+        project="The project name to bind to this channel",
+        branch="Optional branch override (defaults to channel name)",
+    )
+    async def bind_command(
+        interaction: discord.Interaction,
+        project: str,
+        branch: str | None = None,
+    ) -> None:
+        """Bind a channel to a project."""
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        channel_id = interaction.channel_id
+        guild_id = interaction.guild.id
+
+        # Get branch from channel name if not provided
+        if branch is None:
+            mapping = mapper.get_channel_mapping(guild_id, channel_id)
+            if mapping is not None:
+                branch = mapping.branch
+            else:
+                branch = "main"
+
+        from .types import DiscordChannelContext
+
+        context = DiscordChannelContext(project=project, branch=branch)
+        await state_store.set_context(guild_id, channel_id, context)
+
+        await interaction.response.send_message(
+            f"Bound channel to project `{project}` branch `{branch}`.",
+            ephemeral=True,
+        )
+
+    @tree.command(name="unbind", description="Remove project binding from this channel")
+    async def unbind_command(interaction: discord.Interaction) -> None:
+        """Unbind a channel from its project."""
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        channel_id = interaction.channel_id
+        guild_id = interaction.guild.id
+
+        await state_store.clear_channel(guild_id, channel_id)
+        await interaction.response.send_message(
+            "Channel binding removed.", ephemeral=True
+        )
+
+    @tree.command(name="cancel", description="Cancel the currently running task")
+    async def cancel_command(interaction: discord.Interaction) -> None:
+        """Cancel a running task."""
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        channel_id = interaction.channel_id
+
+        running = get_running_task(channel_id)
+        if running is None:
+            await interaction.response.send_message(
+                "No task is currently running in this channel.", ephemeral=True
+            )
+            return
+
+        await cancel_task(channel_id)
+        await interaction.response.send_message(
+            "Cancellation requested.", ephemeral=True
+        )
+
+
+def is_bot_mentioned(message: discord.Message, bot_user: discord.User | None) -> bool:
+    """Check if the bot is mentioned in the message."""
+    if bot_user is None:
+        return False
+    return bot_user in message.mentions
+
+
+def should_process_message(
+    message: discord.Message,
+    bot_user: discord.User | None,
+    *,
+    require_mention: bool = False,
+) -> bool:
+    """Determine if a message should be processed by the bot.
+
+    Args:
+        message: The Discord message
+        bot_user: The bot's user object
+        require_mention: If True, only process messages that mention the bot
+    """
+    # Ignore bot messages
+    if message.author.bot:
+        return False
+
+    # Ignore empty messages
+    if not message.content.strip():
+        return False
+
+    # In threads, always process
+    if isinstance(message.channel, discord.Thread):
+        return True
+
+    # In channels, check if mention is required
+    if require_mention:
+        return is_bot_mentioned(message, bot_user)
+
+    return True
+
+
+def extract_prompt_from_message(
+    message: discord.Message,
+    bot_user: discord.User | None,
+) -> str:
+    """Extract the prompt text from a message, removing bot mentions."""
+    content = message.content
+
+    # Remove bot mention if present
+    if bot_user is not None:
+        content = content.replace(f"<@{bot_user.id}>", "").strip()
+        content = content.replace(f"<@!{bot_user.id}>", "").strip()
+
+    return content

--- a/src/dakopi/loop.py
+++ b/src/dakopi/loop.py
@@ -1,0 +1,220 @@
+"""Main event loop for Discord transport."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, cast
+
+import anyio
+import discord
+
+from takopi.logging import get_logger
+from takopi.markdown import MarkdownParts
+from takopi.model import ResumeToken
+from takopi.runner_bridge import RunningTasks
+from takopi.transport import MessageRef, RenderedMessage, SendOptions
+
+from .bridge import CANCEL_BUTTON_ID, DiscordBridgeConfig, DiscordTransport
+from .handlers import (
+    extract_prompt_from_message,
+    register_slash_commands,
+    should_process_message,
+)
+from .mapping import CategoryChannelMapper
+from .render import prepare_discord
+from .state import DiscordStateStore
+from .types import DiscordChannelContext
+
+if TYPE_CHECKING:
+    from takopi.context import RunContext
+
+logger = get_logger(__name__)
+
+__all__ = ["run_main_loop"]
+
+
+async def _send_startup(cfg: DiscordBridgeConfig, channel_id: int) -> None:
+    """Send startup message to the specified channel."""
+    logger.debug("startup.message", text=cfg.startup_msg)
+    parts = MarkdownParts(header=cfg.startup_msg)
+    text = prepare_discord(parts)
+    message = RenderedMessage(text=text, extra={})
+    sent = await cfg.exec_cfg.transport.send(
+        channel_id=channel_id,
+        message=message,
+    )
+    if sent is not None:
+        logger.info("startup.sent", channel_id=channel_id)
+
+
+async def run_main_loop(
+    cfg: DiscordBridgeConfig,
+    *,
+    default_engine_override: str | None = None,
+) -> None:
+    """Run the main Discord event loop."""
+    running_tasks: RunningTasks = {}
+    config_path = cfg.runtime.config_path
+    state_store = DiscordStateStore(config_path) if config_path else None
+    mapper = CategoryChannelMapper(cfg.bot)
+    transport = cast(DiscordTransport, cfg.exec_cfg.transport)
+
+    def get_running_task(channel_id: int) -> int | None:
+        """Get the message ID of a running task in a channel."""
+        for key, task in running_tasks.items():
+            if key[0] == channel_id:
+                return key[1]
+        return None
+
+    async def cancel_task(channel_id: int) -> None:
+        """Cancel a running task in a channel."""
+        for key, task in list(running_tasks.items()):
+            if key[0] == channel_id:
+                task.cancel_scope.cancel()
+                break
+
+    # Register slash commands
+    register_slash_commands(
+        cfg.bot,
+        state_store=state_store,
+        mapper=mapper,
+        get_running_task=get_running_task,
+        cancel_task=cancel_task,
+    )
+
+    async def run_job(
+        channel_id: int,
+        user_msg_id: int,
+        text: str,
+        resume_token: ResumeToken | None,
+        context: RunContext | None,
+        thread_id: int | None = None,
+        reply_ref: MessageRef | None = None,
+    ) -> None:
+        """Run an engine job."""
+        from takopi.runner_bridge import run_engine
+
+        await run_engine(
+            exec_cfg=cfg.exec_cfg,
+            runtime=cfg.runtime,
+            running_tasks=running_tasks,
+            chat_id=channel_id,
+            user_msg_id=user_msg_id,
+            text=text,
+            resume_token=resume_token,
+            context=context,
+            reply_ref=reply_ref,
+            thread_id=thread_id,
+            show_resume_line=cfg.show_resume_line,
+        )
+
+    async def handle_message(message: discord.Message) -> None:
+        """Handle an incoming Discord message."""
+        if not should_process_message(message, cfg.bot.user, require_mention=False):
+            return
+
+        channel_id = message.channel.id
+        guild_id = message.guild.id if message.guild else None
+        thread_id = None
+
+        # Check if this is a thread
+        if isinstance(message.channel, discord.Thread):
+            thread_id = message.channel.id
+            parent = message.channel.parent
+            if parent:
+                channel_id = parent.id
+
+        # Get context from state or infer from channel
+        context_data: DiscordChannelContext | None = None
+        if state_store and guild_id:
+            context_data = await state_store.get_context(guild_id, channel_id)
+
+        if context_data is None and guild_id:
+            mapping = mapper.get_channel_mapping(guild_id, channel_id)
+            if mapping:
+                context_data = mapper.get_context_from_mapping(mapping)
+
+        # Build run context if we have channel context
+        run_context: RunContext | None = None
+        if context_data:
+            from takopi.context import RunContext
+
+            run_context = RunContext(
+                project=context_data.project,
+                branch=context_data.branch,
+            )
+
+        # Extract prompt
+        prompt = extract_prompt_from_message(message, cfg.bot.user)
+        if not prompt.strip():
+            return
+
+        # Get resume token if in stateful mode
+        resume_token: ResumeToken | None = None
+        if state_store and guild_id and cfg.session_mode == "chat":
+            engine_id = cfg.runtime.default_engine or "claude"
+            token_str = await state_store.get_session(guild_id, channel_id, engine_id)
+            if token_str:
+                resume_token = ResumeToken(token_str)
+
+        # Create thread for the response if not already in a thread
+        if thread_id is None and isinstance(message.channel, discord.TextChannel):
+            # Send initial reply then create thread from it
+            pass  # For now, just reply in channel
+
+        reply_ref = MessageRef(
+            channel_id=channel_id,
+            message_id=message.id,
+            thread_id=thread_id,
+        )
+
+        logger.info(
+            "message.received",
+            channel_id=channel_id,
+            message_id=message.id,
+            author=message.author.name,
+            prompt_length=len(prompt),
+        )
+
+        await run_job(
+            channel_id=thread_id or channel_id,
+            user_msg_id=message.id,
+            text=prompt,
+            resume_token=resume_token,
+            context=run_context,
+            thread_id=thread_id,
+            reply_ref=reply_ref,
+        )
+
+    # Set up message handler
+    cfg.bot.set_message_handler(handle_message)
+
+    # Handle cancel button interactions
+    @cfg.bot.client.event
+    async def on_interaction(interaction: discord.Interaction) -> None:
+        if interaction.type != discord.InteractionType.component:
+            return
+        if not interaction.data:
+            return
+        custom_id = interaction.data.get("custom_id")
+        if custom_id == CANCEL_BUTTON_ID:
+            await transport.handle_cancel_interaction(interaction)
+
+    # Start the bot
+    await cfg.bot.start()
+
+    # Send startup message to first available text channel
+    if cfg.guild_id:
+        guild = cfg.bot.get_guild(cfg.guild_id)
+        if guild:
+            for channel in guild.text_channels:
+                await _send_startup(cfg, channel.id)
+                break
+
+    logger.info("bot.ready", user=cfg.bot.user.name if cfg.bot.user else "unknown")
+
+    # Keep running until cancelled
+    try:
+        await anyio.sleep_forever()
+    finally:
+        await cfg.bot.close()

--- a/src/dakopi/mapping.py
+++ b/src/dakopi/mapping.py
@@ -1,0 +1,171 @@
+"""Category/channel to project/branch mapping."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import discord
+
+from .types import DiscordChannelContext
+
+if TYPE_CHECKING:
+    from .client import DiscordBotClient
+
+# Channel naming conventions
+MAIN_BRANCH_NAMES = {"main", "master"}
+ISSUE_PATTERN = re.compile(r"^issue-(\d+)(?:-(.+))?$")
+FEAT_PATTERN = re.compile(r"^feat-(.+)$")
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelMapping:
+    """Mapping of a Discord channel to a project/branch."""
+
+    guild_id: int
+    category_id: int | None
+    category_name: str | None
+    channel_id: int
+    channel_name: str
+    project: str | None
+    branch: str
+
+
+def infer_branch_from_channel_name(channel_name: str) -> str:
+    """Infer the git branch name from a Discord channel name.
+
+    Channel naming conventions:
+    - #main or #master -> main/master branch
+    - #issue-NNN or #issue-NNN-description -> issue-NNN or issue-NNN-description
+    - #feat-name -> feat-name or feat/name
+    - Other -> use channel name as-is
+    """
+    name = channel_name.lower().strip()
+
+    # Main/master branches
+    if name in MAIN_BRANCH_NAMES:
+        return name
+
+    # Issue branches: issue-123 or issue-123-fix-bug
+    issue_match = ISSUE_PATTERN.match(name)
+    if issue_match:
+        issue_num = issue_match.group(1)
+        description = issue_match.group(2)
+        if description:
+            return f"issue-{issue_num}-{description}"
+        return f"issue-{issue_num}"
+
+    # Feature branches: feat-name
+    feat_match = FEAT_PATTERN.match(name)
+    if feat_match:
+        return f"feat-{feat_match.group(1)}"
+
+    # Default: use channel name as branch
+    return name
+
+
+def infer_project_from_category_name(category_name: str) -> str:
+    """Infer the project name from a Discord category name.
+
+    Converts to lowercase and replaces spaces with hyphens.
+    """
+    return category_name.lower().strip().replace(" ", "-")
+
+
+class CategoryChannelMapper:
+    """Maps Discord categories and channels to projects and branches."""
+
+    def __init__(self, bot: DiscordBotClient) -> None:
+        self._bot = bot
+
+    def get_channel_mapping(
+        self,
+        guild_id: int,
+        channel_id: int,
+    ) -> ChannelMapping | None:
+        """Get the mapping for a channel."""
+        channel = self._bot.get_channel(channel_id)
+        if channel is None:
+            return None
+
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            return None
+
+        # For threads, get the parent channel
+        if isinstance(channel, discord.Thread):
+            parent = channel.parent
+            if parent is None or not isinstance(parent, discord.TextChannel):
+                return None
+            channel = parent
+
+        category = channel.category
+        category_id = category.id if category else None
+        category_name = category.name if category else None
+
+        # Infer project from category name if available
+        project = None
+        if category_name is not None:
+            project = infer_project_from_category_name(category_name)
+
+        # Infer branch from channel name
+        branch = infer_branch_from_channel_name(channel.name)
+
+        return ChannelMapping(
+            guild_id=guild_id,
+            category_id=category_id,
+            category_name=category_name,
+            channel_id=channel.id,
+            channel_name=channel.name,
+            project=project,
+            branch=branch,
+        )
+
+    def get_context_from_mapping(
+        self,
+        mapping: ChannelMapping,
+        *,
+        default_project: str | None = None,
+    ) -> DiscordChannelContext | None:
+        """Convert a channel mapping to a context.
+
+        Args:
+            mapping: The channel mapping
+            default_project: Default project if category doesn't map to one
+        """
+        project = mapping.project or default_project
+        if project is None:
+            return None
+        return DiscordChannelContext(project=project, branch=mapping.branch)
+
+    def list_category_channels(
+        self,
+        guild_id: int,
+        category_id: int,
+    ) -> list[ChannelMapping]:
+        """List all channels in a category."""
+        guild = self._bot.get_guild(guild_id)
+        if guild is None:
+            return []
+
+        category = guild.get_channel(category_id)
+        if not isinstance(category, discord.CategoryChannel):
+            return []
+
+        mappings: list[ChannelMapping] = []
+        for channel in category.channels:
+            if isinstance(channel, discord.TextChannel):
+                branch = infer_branch_from_channel_name(channel.name)
+                project = infer_project_from_category_name(category.name)
+                mappings.append(
+                    ChannelMapping(
+                        guild_id=guild_id,
+                        category_id=category_id,
+                        category_name=category.name,
+                        channel_id=channel.id,
+                        channel_name=channel.name,
+                        project=project,
+                        branch=branch,
+                    )
+                )
+        return mappings

--- a/src/dakopi/onboarding.py
+++ b/src/dakopi/onboarding.py
@@ -1,0 +1,378 @@
+"""Setup and onboarding for Discord transport."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import anyio
+import questionary
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from takopi.backends import EngineBackend, SetupIssue
+from takopi.backends_helpers import install_issue
+from takopi.config import (
+    ConfigError,
+    dump_toml,
+    ensure_table,
+    read_config,
+    write_config,
+)
+from takopi.engines import list_backends
+from takopi.logging import suppress_logs
+from takopi.settings import HOME_CONFIG_PATH, load_settings
+from takopi.transports import SetupResult
+
+__all__ = [
+    "check_setup",
+    "interactive_setup",
+    "mask_token",
+]
+
+
+def _display_path(path: Path) -> str:
+    home = Path.home()
+    try:
+        return f"~/{path.relative_to(home)}"
+    except ValueError:
+        return str(path)
+
+
+_CREATE_CONFIG_TITLE = "create a config"
+_CONFIGURE_DISCORD_TITLE = "configure discord"
+
+
+def config_issue(path: Path, *, title: str) -> SetupIssue:
+    return SetupIssue(title, (f"   {_display_path(path)}",))
+
+
+def _require_discord(settings, config_path: Path) -> Any:
+    """Check if Discord transport is configured."""
+    transports = getattr(settings, "transports", None)
+    if transports is None:
+        raise ConfigError(f"no transports configured in {config_path}")
+
+    # Check for discord in extra fields since it's a plugin
+    discord_config = getattr(transports, "discord", None)
+    if discord_config is None:
+        # Try model_extra for pydantic extra fields
+        extra = getattr(transports, "model_extra", {}) or {}
+        discord_config = extra.get("discord")
+
+    if discord_config is None:
+        raise ConfigError(f"discord transport not configured in {config_path}")
+
+    # Validate required fields
+    if isinstance(discord_config, dict):
+        if not discord_config.get("bot_token"):
+            raise ConfigError("discord.bot_token is required")
+    else:
+        if not getattr(discord_config, "bot_token", None):
+            raise ConfigError("discord.bot_token is required")
+
+    return discord_config
+
+
+def check_setup(
+    backend: EngineBackend,
+    *,
+    transport_override: str | None = None,
+) -> SetupResult:
+    """Check if Discord transport is properly set up."""
+    issues: list[SetupIssue] = []
+    config_path = HOME_CONFIG_PATH
+    cmd = backend.cli_cmd or backend.id
+    backend_issues: list[SetupIssue] = []
+    if shutil.which(cmd) is None:
+        backend_issues.append(install_issue(cmd, backend.install_cmd))
+
+    try:
+        settings, config_path = load_settings()
+        if transport_override:
+            settings = settings.model_copy(update={"transport": transport_override})
+        try:
+            _require_discord(settings, config_path)
+        except ConfigError:
+            issues.append(config_issue(config_path, title=_CONFIGURE_DISCORD_TITLE))
+    except ConfigError:
+        issues.extend(backend_issues)
+        title = (
+            _CONFIGURE_DISCORD_TITLE
+            if config_path.exists() and config_path.is_file()
+            else _CREATE_CONFIG_TITLE
+        )
+        issues.append(config_issue(config_path, title=title))
+        return SetupResult(issues=issues, config_path=config_path)
+
+    issues.extend(backend_issues)
+    return SetupResult(issues=issues, config_path=config_path)
+
+
+def mask_token(token: str) -> str:
+    """Mask a bot token for display."""
+    token = token.strip()
+    if len(token) <= 12:
+        return "*" * len(token)
+    return f"{token[:9]}...{token[-5:]}"
+
+
+async def _validate_discord_token(token: str) -> tuple[str, str] | None:
+    """Validate a Discord bot token and return (bot_id, bot_name) if valid."""
+    import discord
+
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+
+    try:
+        ready_event = anyio.Event()
+        bot_info: dict[str, Any] = {}
+
+        @client.event
+        async def on_ready() -> None:
+            if client.user:
+                bot_info["id"] = str(client.user.id)
+                bot_info["name"] = client.user.name
+            ready_event.set()
+
+        # Start client in background
+        async def run_client() -> None:
+            try:
+                await client.start(token)
+            except discord.LoginFailure:
+                ready_event.set()
+            except Exception:
+                ready_event.set()
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_client)
+
+            # Wait for ready or timeout
+            with anyio.move_on_after(10):
+                await ready_event.wait()
+
+            tg.cancel_scope.cancel()
+
+        if bot_info.get("id"):
+            return bot_info["id"], bot_info["name"]
+        return None
+    finally:
+        if not client.is_closed():
+            await client.close()
+
+
+def _render_engine_table(console: Console) -> list[tuple[str, bool, str | None]]:
+    """Render a table of available engines."""
+    backends = list_backends()
+    rows: list[tuple[str, bool, str | None]] = []
+    table = Table(show_header=True, header_style="bold", box=box.SIMPLE)
+    table.add_column("agent")
+    table.add_column("status")
+    table.add_column("install command")
+    for backend in backends:
+        cmd = backend.cli_cmd or backend.id
+        installed = shutil.which(cmd) is not None
+        status = "[green]✓ installed[/]" if installed else "[dim]✗ not found[/]"
+        rows.append((backend.id, installed, backend.install_cmd))
+        table.add_row(
+            backend.id,
+            status,
+            "" if installed else (backend.install_cmd or "-"),
+        )
+    console.print(table)
+    return rows
+
+
+def _confirm(console: Console, message: str, *, default: bool = True) -> bool | None:
+    """Simple yes/no confirmation."""
+    result = questionary.confirm(message, default=default).ask()
+    return result
+
+
+def _prompt_token(console: Console) -> tuple[str, str, str] | None:
+    """Prompt for and validate a Discord bot token.
+
+    Returns (token, bot_id, bot_name) if successful.
+    """
+    while True:
+        token = questionary.password("paste your discord bot token:").ask()
+        if token is None:
+            return None
+        token = token.strip()
+        if not token:
+            console.print("  token cannot be empty")
+            continue
+        console.print("  validating...")
+        with suppress_logs():
+            result = anyio.run(_validate_discord_token, token)
+        if result:
+            bot_id, bot_name = result
+            console.print(f"  connected to {bot_name} (ID: {bot_id})")
+            return token, bot_id, bot_name
+        console.print("  failed to connect, check the token and try again")
+        retry = _confirm(console, "try again?", default=True)
+        if not retry:
+            return None
+
+
+def interactive_setup(*, force: bool) -> bool:
+    """Run interactive setup for Discord transport."""
+    console = Console()
+    config_path = HOME_CONFIG_PATH
+
+    if config_path.exists() and not force:
+        console.print(
+            f"config already exists at {_display_path(config_path)}. "
+            "use --onboard to reconfigure."
+        )
+        return True
+
+    if config_path.exists() and force:
+        overwrite = _confirm(
+            console,
+            f"update existing config at {_display_path(config_path)}?",
+            default=False,
+        )
+        if not overwrite:
+            return False
+
+    with suppress_logs():
+        panel = Panel(
+            "let's set up your discord bot.",
+            title="welcome to dakopi!",
+            border_style="blue",
+            padding=(1, 2),
+            expand=False,
+        )
+        console.print(panel)
+
+        console.print("step 1: discord bot setup\n")
+        have_token = _confirm(console, "do you have a discord bot token?")
+        if have_token is None:
+            return False
+        if not have_token:
+            console.print("  1. go to https://discord.com/developers/applications")
+            console.print("  2. click 'New Application' and give it a name")
+            console.print("  3. go to 'Bot' section and click 'Reset Token'")
+            console.print("  4. copy the token")
+            console.print("  5. enable 'Message Content Intent' under Privileged Gateway Intents")
+            console.print("")
+
+        token_info = _prompt_token(console)
+        if token_info is None:
+            return False
+        token, bot_id, bot_name = token_info
+
+        console.print("\nstep 2: invite bot to server\n")
+        # Generate invite URL with required permissions
+        permissions = 277025770560  # Send messages, manage threads, etc.
+        invite_url = f"https://discord.com/api/oauth2/authorize?client_id={bot_id}&permissions={permissions}&scope=bot%20applications.commands"
+        console.print(f"  invite URL: {invite_url}")
+        console.print("")
+        console.print("  open the URL above and add the bot to your server")
+        input("  press Enter when done...")
+
+        # Optional: prompt for guild ID
+        guild_id: int | None = None
+        use_guild = _confirm(console, "restrict bot to a specific server?", default=False)
+        if use_guild:
+            guild_id_str = questionary.text("enter server (guild) ID:").ask()
+            if guild_id_str:
+                try:
+                    guild_id = int(guild_id_str.strip())
+                except ValueError:
+                    console.print("  invalid guild ID, skipping")
+
+        console.print("\nstep 3: agent cli tools")
+        rows = _render_engine_table(console)
+        installed_ids = [engine_id for engine_id, installed, _ in rows if installed]
+
+        default_engine: str | None = None
+        if installed_ids:
+            default_engine = questionary.select(
+                "choose default agent:",
+                choices=installed_ids,
+            ).ask()
+            if default_engine is None:
+                return False
+        else:
+            console.print("no agents found on PATH. install one to continue.")
+            save_anyway = _confirm(console, "save config anyway?", default=False)
+            if not save_anyway:
+                return False
+
+        # Build preview config
+        preview_config: dict[str, Any] = {}
+        if default_engine is not None:
+            preview_config["default_engine"] = default_engine
+        preview_config["transport"] = "discord"
+        discord_config: dict[str, Any] = {
+            "bot_token": mask_token(token),
+        }
+        if guild_id is not None:
+            discord_config["guild_id"] = guild_id
+        preview_config["transports"] = {"discord": discord_config}
+
+        config_preview = dump_toml(preview_config).rstrip()
+        console.print("\nstep 4: save configuration\n")
+        console.print(f"  {_display_path(config_path)}\n")
+        for line in config_preview.splitlines():
+            console.print(f"  {line}")
+        console.print("")
+
+        save = _confirm(
+            console,
+            f"save this config to {_display_path(config_path)}?",
+            default=True,
+        )
+        if not save:
+            return False
+
+        # Read existing config and merge
+        raw_config: dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                raw_config = read_config(config_path)
+            except ConfigError as exc:
+                console.print(f"[yellow]warning:[/] config is malformed: {exc}")
+                backup = config_path.with_suffix(".toml.bak")
+                try:
+                    shutil.copyfile(config_path, backup)
+                except OSError as copy_exc:
+                    console.print(
+                        f"[yellow]warning:[/] failed to back up config: {copy_exc}"
+                    )
+                else:
+                    console.print(f"  backed up to {_display_path(backup)}")
+                raw_config = {}
+
+        merged = dict(raw_config)
+        if default_engine is not None:
+            merged["default_engine"] = default_engine
+        merged["transport"] = "discord"
+        transports = ensure_table(merged, "transports", config_path=config_path)
+        discord_section = ensure_table(
+            transports,
+            "discord",
+            config_path=config_path,
+            label="transports.discord",
+        )
+        discord_section["bot_token"] = token
+        if guild_id is not None:
+            discord_section["guild_id"] = guild_id
+
+        write_config(merged, config_path)
+        console.print(f"  config saved to {_display_path(config_path)}")
+
+        done_panel = Panel(
+            "setup complete. run 'takopi run' to start dakopi!",
+            border_style="green",
+            padding=(1, 2),
+            expand=False,
+        )
+        console.print("\n")
+        console.print(done_panel)
+        return True

--- a/src/dakopi/render.py
+++ b/src/dakopi/render.py
@@ -1,0 +1,186 @@
+"""Message rendering for Discord."""
+
+from __future__ import annotations
+
+import re
+
+from takopi.markdown import MarkdownParts, assemble_markdown_parts
+
+# Discord has a 2000 character limit per message
+MAX_MESSAGE_CHARS = 2000
+MAX_BODY_CHARS = 1500  # Leave room for header/footer
+
+_FENCE_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<fence>[`~]{3,})(?P<info>.*)$")
+
+
+class _FenceState:
+    __slots__ = ("fence", "indent", "header")
+
+    def __init__(self, fence: str, indent: str, header: str) -> None:
+        self.fence = fence
+        self.indent = indent
+        self.header = header
+
+
+def _update_fence_state(line: str, state: _FenceState | None) -> _FenceState | None:
+    match = _FENCE_RE.match(line)
+    if match is None:
+        return state
+    fence = match.group("fence")
+    indent = match.group("indent")
+    if state is None:
+        return _FenceState(fence=fence, indent=indent, header=line)
+    if fence[0] == state.fence[0] and len(fence) >= len(state.fence):
+        return None
+    return state
+
+
+def _scan_fence_state(text: str, state: _FenceState | None) -> _FenceState | None:
+    for line in text.splitlines():
+        state = _update_fence_state(line, state)
+    return state
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    if text.endswith("\n") or text.endswith("\r"):
+        return text
+    return text + "\n"
+
+
+def _close_fence_chunk(text: str, state: _FenceState) -> str:
+    return _ensure_trailing_newline(text) + f"{state.indent}{state.fence}\n"
+
+
+def _reopen_fence_prefix(state: _FenceState) -> str:
+    return f"{state.header}\n"
+
+
+def _split_long_line(line: str, max_chars: int) -> list[str]:
+    if len(line) <= max_chars:
+        return [line]
+    # Split line preserving ending
+    ending = ""
+    if line.endswith("\r\n"):
+        line, ending = line[:-2], "\r\n"
+    elif line.endswith("\n"):
+        line, ending = line[:-1], "\n"
+    elif line.endswith("\r"):
+        line, ending = line[:-1], "\r"
+
+    parts: list[str] = []
+    for idx in range(0, len(line), max_chars):
+        chunk = line[idx : idx + max_chars]
+        if idx + max_chars >= len(line):
+            chunk += ending
+        parts.append(chunk)
+    return parts if parts else [ending] if ending else []
+
+
+def _split_block(block: str, max_chars: int) -> list[str]:
+    if len(block) <= max_chars:
+        return [block]
+    pieces: list[str] = []
+    current = ""
+    for line in block.splitlines(keepends=True):
+        for part in _split_long_line(line, max_chars):
+            if not part:
+                continue
+            if current and len(current) + len(part) > max_chars:
+                pieces.append(current)
+                current = ""
+            current += part
+            if len(current) == max_chars:
+                pieces.append(current)
+                current = ""
+    if current:
+        pieces.append(current)
+    return pieces
+
+
+def split_markdown_body(body: str, max_chars: int) -> list[str]:
+    """Split markdown body into chunks respecting code fences."""
+    if not body or not body.strip():
+        return []
+    max_chars = max(1, int(max_chars))
+    segments = re.split(r"(\n{2,})", body)
+    blocks: list[str] = []
+    for idx in range(0, len(segments), 2):
+        paragraph = segments[idx]
+        separator = segments[idx + 1] if idx + 1 < len(segments) else ""
+        block = paragraph + separator
+        if block:
+            blocks.append(block)
+
+    chunks: list[str] = []
+    current = ""
+    state: _FenceState | None = None
+    for block in blocks:
+        for piece in _split_block(block, max_chars):
+            if not current:
+                current = piece
+                state = _scan_fence_state(piece, state)
+                continue
+            if len(current) + len(piece) <= max_chars:
+                current += piece
+                state = _scan_fence_state(piece, state)
+                continue
+
+            if state is not None:
+                current = _close_fence_chunk(current, state)
+            chunks.append(current)
+            current = _reopen_fence_prefix(state) if state is not None else ""
+            current += piece
+            state = _scan_fence_state(piece, state)
+
+    if current:
+        chunks.append(current)
+
+    return [chunk for chunk in chunks if chunk.strip()]
+
+
+def trim_body(body: str | None, *, max_chars: int = MAX_BODY_CHARS) -> str | None:
+    """Trim body to max chars with ellipsis."""
+    if not body:
+        return None
+    if len(body) > max_chars:
+        body = body[: max_chars - 1] + "…"
+    return body if body.strip() else None
+
+
+def prepare_discord(parts: MarkdownParts) -> str:
+    """Render markdown parts to Discord-compatible message."""
+    trimmed = MarkdownParts(
+        header=parts.header or "",
+        body=trim_body(parts.body, max_chars=MAX_BODY_CHARS),
+        footer=parts.footer,
+    )
+    # Discord supports markdown natively, so just assemble
+    return assemble_markdown_parts(trimmed)
+
+
+def prepare_discord_multi(
+    parts: MarkdownParts, *, max_body_chars: int = MAX_BODY_CHARS
+) -> list[str]:
+    """Render markdown parts to multiple Discord messages if needed."""
+    body = parts.body
+    if body is not None and not body.strip():
+        body = None
+    body_chunks = split_markdown_body(body, max_body_chars) if body is not None else []
+    if not body_chunks:
+        body_chunks = [""]
+    total = len(body_chunks)
+
+    messages: list[str] = []
+    for idx, chunk in enumerate(body_chunks, start=1):
+        header = parts.header or ""
+        if idx > 1:
+            if header:
+                header = f"{header} · continued ({idx}/{total})"
+            else:
+                header = f"continued ({idx}/{total})"
+        messages.append(
+            assemble_markdown_parts(
+                MarkdownParts(header=header, body=chunk, footer=parts.footer)
+            )
+        )
+    return messages

--- a/src/dakopi/state.py
+++ b/src/dakopi/state.py
@@ -1,0 +1,167 @@
+"""State management for Discord transport."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import anyio
+import msgspec
+
+from .types import DiscordChannelContext
+
+STATE_VERSION = 1
+
+
+class DiscordChannelStateData(msgspec.Struct):
+    """State data for a single channel."""
+
+    context: dict[str, str] | None = None  # {"project": ..., "branch": ...}
+    sessions: dict[str, str] | None = None  # engine_id -> resume_token
+
+
+class DiscordState(msgspec.Struct):
+    """Root state structure."""
+
+    version: int = STATE_VERSION
+    channels: dict[str, DiscordChannelStateData] = msgspec.field(default_factory=dict)
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    """Write JSON atomically using a temp file."""
+    tmp_path = path.with_suffix(".tmp")
+    content = json.dumps(data, indent=2, ensure_ascii=False)
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(path)
+
+
+class DiscordStateStore:
+    """State store for Discord channel mappings and sessions."""
+
+    def __init__(self, config_path: Path) -> None:
+        self._path = config_path.parent / "discord_state.json"
+        self._lock = anyio.Lock()
+        self._loaded = False
+        self._mtime_ns: int | None = None
+        self._state = DiscordState()
+
+    def _stat_mtime_ns(self) -> int | None:
+        try:
+            return self._path.stat().st_mtime_ns
+        except FileNotFoundError:
+            return None
+
+    def _reload_if_needed(self) -> None:
+        current = self._stat_mtime_ns()
+        if self._loaded and current == self._mtime_ns:
+            return
+        self._load()
+
+    def _load(self) -> None:
+        self._loaded = True
+        self._mtime_ns = self._stat_mtime_ns()
+        if self._mtime_ns is None:
+            self._state = DiscordState()
+            return
+        try:
+            payload = msgspec.json.decode(
+                self._path.read_bytes(), type=DiscordState
+            )
+        except Exception:  # noqa: BLE001
+            self._state = DiscordState()
+            return
+        if payload.version != STATE_VERSION:
+            self._state = DiscordState()
+            return
+        self._state = payload
+
+    def _save(self) -> None:
+        payload = msgspec.to_builtins(self._state)
+        _atomic_write_json(self._path, payload)
+        self._mtime_ns = self._stat_mtime_ns()
+
+    @staticmethod
+    def _channel_key(guild_id: int | None, channel_id: int) -> str:
+        if guild_id is not None:
+            return f"{guild_id}:{channel_id}"
+        return str(channel_id)
+
+    async def get_context(
+        self, guild_id: int | None, channel_id: int
+    ) -> DiscordChannelContext | None:
+        """Get the context for a channel."""
+        async with self._lock:
+            self._reload_if_needed()
+            key = self._channel_key(guild_id, channel_id)
+            channel_data = self._state.channels.get(key)
+            if channel_data is None or channel_data.context is None:
+                return None
+            ctx = channel_data.context
+            project = ctx.get("project")
+            branch = ctx.get("branch")
+            if project is None or branch is None:
+                return None
+            return DiscordChannelContext(project=project, branch=branch)
+
+    async def set_context(
+        self,
+        guild_id: int | None,
+        channel_id: int,
+        context: DiscordChannelContext | None,
+    ) -> None:
+        """Set the context for a channel."""
+        async with self._lock:
+            self._reload_if_needed()
+            key = self._channel_key(guild_id, channel_id)
+            if key not in self._state.channels:
+                self._state.channels[key] = DiscordChannelStateData()
+            if context is None:
+                self._state.channels[key].context = None
+            else:
+                self._state.channels[key].context = {
+                    "project": context.project,
+                    "branch": context.branch,
+                }
+            self._save()
+
+    async def get_session(
+        self, guild_id: int | None, channel_id: int, engine_id: str
+    ) -> str | None:
+        """Get the resume token for a session."""
+        async with self._lock:
+            self._reload_if_needed()
+            key = self._channel_key(guild_id, channel_id)
+            channel_data = self._state.channels.get(key)
+            if channel_data is None or channel_data.sessions is None:
+                return None
+            return channel_data.sessions.get(engine_id)
+
+    async def set_session(
+        self,
+        guild_id: int | None,
+        channel_id: int,
+        engine_id: str,
+        resume_token: str | None,
+    ) -> None:
+        """Set or clear the resume token for a session."""
+        async with self._lock:
+            self._reload_if_needed()
+            key = self._channel_key(guild_id, channel_id)
+            if key not in self._state.channels:
+                self._state.channels[key] = DiscordChannelStateData()
+            if self._state.channels[key].sessions is None:
+                self._state.channels[key].sessions = {}
+            if resume_token is None:
+                self._state.channels[key].sessions.pop(engine_id, None)
+            else:
+                self._state.channels[key].sessions[engine_id] = resume_token
+            self._save()
+
+    async def clear_channel(self, guild_id: int | None, channel_id: int) -> None:
+        """Clear all state for a channel."""
+        async with self._lock:
+            self._reload_if_needed()
+            key = self._channel_key(guild_id, channel_id)
+            self._state.channels.pop(key, None)
+            self._save()

--- a/src/dakopi/types.py
+++ b/src/dakopi/types.py
@@ -1,0 +1,58 @@
+"""Type definitions for Discord transport."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordIncomingMessage:
+    """Incoming message from Discord."""
+
+    transport: str
+    guild_id: int | None
+    channel_id: int
+    message_id: int
+    content: str
+    author_id: int
+    author_name: str
+    thread_id: int | None = None
+    reply_to_message_id: int | None = None
+    reply_to_content: str | None = None
+    category_id: int | None = None
+    raw: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordInteraction:
+    """Interaction from Discord (slash commands, buttons)."""
+
+    transport: str
+    guild_id: int | None
+    channel_id: int
+    interaction_id: int
+    interaction_token: str
+    command_name: str | None
+    custom_id: str | None
+    user_id: int
+    user_name: str
+    options: dict[str, Any] | None = None
+    message_id: int | None = None
+    raw: Any | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordChannelContext:
+    """Context for a Discord channel mapped to a project/branch."""
+
+    project: str
+    branch: str
+
+
+@dataclass(frozen=True, slots=True)
+class DiscordChannelState:
+    """State for a Discord channel."""
+
+    context: DiscordChannelContext | None = None
+    sessions: dict[str, str] | None = None  # engine_id -> resume_token


### PR DESCRIPTION
## Summary

- Implements core Discord transport plugin for takopi (Phase 1 from #1)
- Maps Discord structure to takopi's project/branch/session model
- Provides slash commands for channel binding and task management
- Includes interactive setup wizard for bot configuration

## Changes

**Package Structure:**
- `pyproject.toml` - Package config with entry point registration
- `src/dakopi/` - Plugin implementation

**Core Components:**
- `backend.py` - TransportBackend implementation
- `bridge.py` - DiscordTransport and DiscordPresenter
- `client.py` - discord.py wrapper
- `loop.py` - Main event loop
- `handlers.py` - Slash command handlers
- `mapping.py` - Category/channel to project/branch mapping
- `state.py` - State persistence (discord_state.json)
- `render.py` - Markdown rendering for Discord
- `onboarding.py` - Interactive setup

**Slash Commands:**
- `/status` - Show channel context and running tasks
- `/bind <project>` - Bind channel to project
- `/unbind` - Remove binding
- `/cancel` - Cancel running task

## Test plan

- [ ] Install with `uv pip install -e .`
- [ ] Verify plugin loads with `takopi plugins --load`
- [ ] Run `takopi setup` for Discord configuration
- [ ] Test bot connection and slash commands
- [ ] Verify message handling and threading

Closes #1 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)