### PR TITLE
Fix duplicate bind command

### DIFF
--- a/src/takopi_discord/client.py
+++ b/src/takopi_discord/client.py
@@ -106,6 +106,9 @@ class DiscordBotClient:
             guild = discord.Object(id=self._guild_id)
             self._tree.copy_global_to(guild=guild)
             await self._tree.sync(guild=guild)
+            # Clear any stale global commands to avoid duplicates
+            self._tree.clear_commands(guild=None)
+            await self._tree.sync()
         else:
             await self._tree.sync()
 


### PR DESCRIPTION
## Summary
- Clear stale global commands when syncing to a specific guild
- This fixes the issue where duplicate slash commands appeared when `guild_id` was configured after commands had been synced globally

## Test plan
- [ ] Configure bot with a `guild_id`
- [ ] Start the bot and verify only one `/bind` command appears in Discord
- [ ] Verify all slash commands work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)