### PR TITLE
Fix engine slash commands: thread + cancel

### DIFF
--- a/src/takopi_discord/client.py
+++ b/src/takopi_discord/client.py
@@ -498,6 +498,36 @@ class DiscordBotClient:
         except discord.HTTPException:
             return None
 
+    async def create_thread_without_message(
+        self,
+        *,
+        channel_id: int,
+        name: str,
+        auto_archive_duration: int = 1440,  # 24 hours
+    ) -> int | None:
+        """Create a thread without a starter message."""
+        channel = self._bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self._bot.fetch_channel(channel_id)
+            except discord.NotFound:
+                return None
+
+        if not isinstance(channel, discord.TextChannel):
+            return None
+
+        try:
+            thread = await channel.create_thread(
+                name=name,
+                message=None,
+                auto_archive_duration=auto_archive_duration,
+                type=discord.ChannelType.public_thread,
+            )
+            await thread.join()
+            return thread.id
+        except discord.HTTPException:
+            return None
+
     def get_guild(self, guild_id: int) -> discord.Guild | None:
         """Get a guild by ID."""
         return self._bot.get_guild(guild_id)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,6 @@
 """Tests for handlers module."""
 
-from takopi_discord.handlers import parse_branch_prefix
+from takopi_discord.handlers import _format_engine_starter_message, parse_branch_prefix
 
 
 class TestParseBranchPrefix:
@@ -65,3 +65,16 @@ class TestParseBranchPrefix:
         branch, prompt = parse_branch_prefix("@issue-123/fix-bug/v2 do the thing")
         assert branch == "issue-123/fix-bug/v2"
         assert prompt == "do the thing"
+
+
+class TestFormatEngineStarterMessage:
+    def test_short_prompt(self) -> None:
+        assert (
+            _format_engine_starter_message("codex", "hi", max_chars=2000) == "/codex hi"
+        )
+
+    def test_truncates_with_ellipsis(self) -> None:
+        msg = _format_engine_starter_message("codex", "x" * 100, max_chars=20)
+        assert msg.startswith("/codex ")
+        assert msg.endswith("…")
+        assert len(msg) <= 20


### PR DESCRIPTION
Fixes #26\n\n- Engine slash commands (e.g. /codex) now create a thread when run from a text channel\n- Seeds the run with a real message ID so progress/cancel wiring is reliable\n- Saves the resume token for the selected engine so follow-ups in the thread can resume\n