### PR TITLE
Fix plugin slash commands: starter message + background run

### DIFF
--- a/tests/test_command_registration.py
+++ b/tests/test_command_registration.py
@@ -1,0 +1,22 @@
+"""Tests for plugin command registration helpers."""
+
+from __future__ import annotations
+
+from takopi_discord.commands.registration import _format_plugin_starter_message
+
+
+class TestFormatPluginStarterMessage:
+    def test_no_args(self) -> None:
+        assert _format_plugin_starter_message("hello", "", max_chars=2000) == "/hello"
+
+    def test_with_args(self) -> None:
+        assert (
+            _format_plugin_starter_message("hello", "world", max_chars=2000)
+            == "/hello world"
+        )
+
+    def test_truncates_with_ellipsis(self) -> None:
+        msg = _format_plugin_starter_message("hello", "x" * 100, max_chars=20)
+        assert msg.startswith("/hello ")
+        assert msg.endswith("…")
+        assert len(msg) <= 20


### PR DESCRIPTION
Plugin slash commands now:

- Post a starter message to get a real `message_id` (no more 0 placeholder) so replies/progress can reply reliably
- Run dispatch in a background task and immediately close the interaction with an ephemeral "Started" follow-up
- Save resume tokens when an engine run starts (via `on_thread_known`)

Includes small unit tests for starter message formatting and a `tests/conftest.py` to ensure local `src/` is importable during pytest.