### PR TITLE
docs: align uv install and onboarding commands with current takopi CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ TAKOPI (category)
 ## Installation
 
 ```bash
-# Install takopi-discord
-pip install takopi-discord
+# Recommended: install into the takopi tool environment
+uv tool install -U takopi --with takopi-discord
 
-# Or with uv
+# If you're already inside a project virtual environment
 uv pip install takopi-discord
 
 # Verify the transport is loaded
@@ -64,8 +64,19 @@ State is automatically saved to `~/.takopi/discord_state.json`. Chat preferences
 1. Create a Discord application at https://discord.com/developers/applications
 2. Create a bot and copy the token
 3. Enable "Message Content Intent" under Privileged Gateway Intents
-4. Run `takopi setup` and follow the prompts
+4. Run `takopi --onboard --transport discord` and follow the prompts
 5. Invite the bot to your server using the generated URL
+
+## Troubleshooting
+
+- `error: No virtual environment found; run uv venv to create an environment, or pass --system ...`
+  - This happens when `uv pip install ...` is run outside a project venv.
+  - If you installed Takopi with `uv tool install`, install this plugin with:
+    - `uv tool install -U takopi --with takopi-discord`
+- `Error: No such command 'setup'`
+  - `takopi setup` is not a core command in current Takopi.
+  - Use onboarding via:
+    - `takopi --onboard --transport discord`
 
 ## Slash Commands
 

--- a/src/takopi_discord/onboarding.py
+++ b/src/takopi_discord/onboarding.py
@@ -371,7 +371,8 @@ async def interactive_setup(*, force: bool) -> bool:
         console.print(f"  config saved to {_display_path(config_path)}")
 
         done_panel = Panel(
-            "setup complete. run 'takopi run' to start takopi-discord!\n\n"
+            "setup complete. run 'takopi' (or 'takopi --transport discord') "
+            "to start takopi-discord!\n\n"
             "tip: the first channel you message the bot in will become\n"
             "the startup channel where status messages are posted.",
             border_style="green",


### PR DESCRIPTION
## Summary
This PR fixes installation/onboarding documentation drift that causes a broken first-run experience when users follow current Takopi install docs (`uv tool install -U takopi`) and then try to install `takopi-discord`.

## Problem
Following the current docs flow:
1. Install Takopi as a uv tool (`uv tool install -U takopi`)
2. Install takopi-discord with `uv pip install takopi-discord`

Users hit:
- `error: No virtual environment found; run uv venv to create an environment, or pass --system ...`

Then after installing via `uv tool install -U takopi --with takopi-discord`, README setup instructions still say:
- `takopi setup`

Which fails with:
- `Error: No such command 'setup'`

## Root Cause
- `uv tool install` creates an isolated tool environment.
- `uv pip install` expects an active project venv (unless `--system`), so it fails in the tool-install scenario.
- Current Takopi CLI onboarding is driven via `--onboard` (and transport selection), not a `setup` subcommand.
- README/onboarding messaging in `takopi-discord` was stale for current Takopi CLI behavior.

## Changes
### README updates
- Prefer tool-compatible install path:
  - `uv tool install -U takopi --with takopi-discord`
- Keep `uv pip install takopi-discord` as the project-venv path.
- Replace `takopi setup` with:
  - `takopi --onboard --transport discord`
- Add a Troubleshooting section explicitly covering:
  - `No virtual environment found` (and why)
  - `No such command 'setup'` (and the correct onboarding command)

### Onboarding UX text
- Update completion message in `src/takopi_discord/onboarding.py`:
  - from `takopi run`
  - to `takopi` (or `takopi --transport discord`)

## Why fix this here?
This mismatch is user-facing within `takopi-discord` docs and onboarding copy, so the fastest high-impact fix is in this repo. It avoids users concluding plugin commands failed to register when the real issue is command/docs drift.

## Scope
- No runtime behavior changes to transport/plugin loading.
- No changes to entry points or command registration internals.
- Docs + onboarding text only.

## Manual validation
- Verified README now reflects the uv tool install path used by Takopi core docs.
- Verified setup command in docs now matches current Takopi CLI onboarding flow.
- Verified onboarding completion message no longer references stale `takopi run` invocation.
