### PR TITLE
Discord: add /ctx set

### DIFF
--- a/src/takopi_discord/handlers.py
+++ b/src/takopi_discord/handlers.py
@@ -51,6 +51,209 @@ async def _require_admin(ctx: discord.ApplicationContext) -> bool:
     return True
 
 
+def _normalize_branch_name(value: str) -> str:
+    branch = value.strip()
+    if branch.startswith("@"):
+        branch = branch[1:]
+    return branch.strip()
+
+
+async def _handle_ctx_command(
+    ctx: discord.ApplicationContext,
+    *,
+    action: str | None,
+    project: str | None,
+    branch: str | None,
+    state_store: DiscordStateStore,
+) -> None:
+    """Handle /ctx show|clear|set for channel/thread context."""
+    from .types import DiscordChannelContext, DiscordThreadContext
+
+    if ctx.guild is None:
+        await ctx.respond("This command can only be used in a server.", ephemeral=True)
+        return
+
+    guild_id = ctx.guild.id
+    channel_id = ctx.channel_id
+    thread_id = None
+
+    if isinstance(ctx.channel, discord.Thread):
+        thread_id = ctx.channel_id
+        channel_id = ctx.channel.parent_id or ctx.channel_id
+
+    channel_context: DiscordChannelContext | None = None
+    thread_context: DiscordThreadContext | None = None
+
+    if thread_id is not None:
+        ctx_data = await state_store.get_context(guild_id, thread_id)
+        if isinstance(ctx_data, DiscordThreadContext):
+            thread_context = ctx_data
+
+    ctx_data = await state_store.get_context(guild_id, channel_id)
+    if isinstance(ctx_data, DiscordChannelContext):
+        channel_context = ctx_data
+
+    if action is None:
+        action = "show"
+
+    if action == "clear":
+        if not await _require_admin(ctx):
+            return
+        target_id = thread_id if thread_id is not None else channel_id
+        await state_store.set_context(guild_id, target_id, None)
+        cleared = "thread" if thread_id is not None else "channel"
+        await ctx.respond(f"{cleared.title()} context binding cleared.", ephemeral=True)
+        return
+
+    if action == "set":
+        if not await _require_admin(ctx):
+            return
+
+        if branch is not None and not branch.strip():
+            branch = None
+        normalized_branch = (
+            _normalize_branch_name(branch) if branch is not None else None
+        )
+
+        if thread_id is not None:
+            if project is not None:
+                await ctx.respond(
+                    "In threads, `/ctx set` only supports rebinding the branch.\n"
+                    "Use `/ctx set <project> [@base-branch]` in the parent channel to change the project.",
+                    ephemeral=True,
+                )
+                return
+            if normalized_branch is None:
+                await ctx.respond(
+                    "Usage (in a thread): `/ctx set @branch-name`", ephemeral=True
+                )
+                return
+
+            base = thread_context or channel_context
+            if base is None:
+                await ctx.respond(
+                    "No project is bound for this thread/channel.\n"
+                    "Use `/bind <project>` (or `/ctx set <project>`) in the parent channel first.",
+                    ephemeral=True,
+                )
+                return
+
+            new_thread_context = DiscordThreadContext(
+                project=base.project,
+                branch=normalized_branch,
+                worktrees_dir=base.worktrees_dir,
+                default_engine=base.default_engine,
+            )
+            await state_store.set_context(guild_id, thread_id, new_thread_context)
+            await ctx.respond(
+                "Thread context updated.\n"
+                f"- Project: `{new_thread_context.project}`\n"
+                f"- Branch: `{new_thread_context.branch}`",
+                ephemeral=True,
+            )
+            return
+
+        # Channel update.
+        if project is None and channel_context is None:
+            await ctx.respond(
+                "No context is bound to this channel.\n"
+                "Usage: `/ctx set <project> [@base-branch]`",
+                ephemeral=True,
+            )
+            return
+
+        if project is None:
+            project = channel_context.project if channel_context is not None else None
+
+        if project is None:
+            await ctx.respond(
+                "Usage: `/ctx set <project> [@base-branch]`", ephemeral=True
+            )
+            return
+
+        worktrees_dir = (
+            channel_context.worktrees_dir if channel_context else ".worktrees"
+        )
+        default_engine = channel_context.default_engine if channel_context else "claude"
+        worktree_base = (
+            normalized_branch
+            if normalized_branch is not None
+            else (channel_context.worktree_base if channel_context else "main")
+        )
+
+        new_channel_context = DiscordChannelContext(
+            project=project,
+            worktrees_dir=worktrees_dir,
+            default_engine=default_engine,
+            worktree_base=worktree_base,
+        )
+        await state_store.set_context(guild_id, channel_id, new_channel_context)
+        await ctx.respond(
+            "Channel context updated.\n"
+            f"- Project: `{new_channel_context.project}`\n"
+            f"- Base branch: `{new_channel_context.worktree_base}`",
+            ephemeral=True,
+        )
+        return
+
+    # Show context (report bound + resolved)
+    resolved_project: str | None = None
+    resolved_branch: str | None = None
+    resolved_engine: str | None = None
+    resolved_source: str | None = None
+
+    if thread_context is not None:
+        resolved_project = thread_context.project
+        resolved_branch = thread_context.branch
+        resolved_engine = thread_context.default_engine
+        resolved_source = "thread"
+    elif channel_context is not None:
+        resolved_project = channel_context.project
+        resolved_branch = channel_context.worktree_base
+        resolved_engine = channel_context.default_engine
+        resolved_source = "channel"
+
+    if resolved_project is None or resolved_branch is None or resolved_engine is None:
+        await ctx.respond(
+            "No context bound to this channel/thread.\n"
+            "Use `/bind <project>` to set up this channel.",
+            ephemeral=True,
+        )
+        return
+
+    lines = [
+        "**Context**",
+        "**Resolved**",
+        f"- Project: `{resolved_project}`",
+        f"- Branch: `{resolved_branch}`",
+        f"- Engine: `{resolved_engine}`",
+        f"- Source: {resolved_source}",
+        "",
+        "**Bound**",
+    ]
+
+    if channel_context is not None:
+        lines.append(
+            f"- Channel: `{channel_context.project}` @ `{channel_context.worktree_base}`"
+        )
+        lines.append(f"  - Engine: `{channel_context.default_engine}`")
+        lines.append(f"  - Worktrees dir: `{channel_context.worktrees_dir}`")
+    else:
+        lines.append("- Channel: _none_")
+
+    if thread_id is not None:
+        if thread_context is not None:
+            lines.append(
+                f"- Thread: `{thread_context.project}` @ `{thread_context.branch}`"
+            )
+            lines.append(f"  - Engine: `{thread_context.default_engine}`")
+            lines.append(f"  - Worktrees dir: `{thread_context.worktrees_dir}`")
+        else:
+            lines.append("- Thread: _none_")
+
+    await ctx.respond("\n".join(lines), ephemeral=True)
+
+
 def register_slash_commands(
     bot: DiscordBotClient,
     *,
@@ -234,54 +437,26 @@ def register_slash_commands(
         ctx: discord.ApplicationContext,
         action: str | None = discord.Option(
             default=None,
-            description="Action to perform (show or clear)",
-            choices=["show", "clear"],
+            description="Action to perform (show, clear, or set)",
+            choices=["show", "clear", "set"],
+        ),
+        project: str | None = discord.Option(
+            default=None,
+            description="Project path (channel only): ~/dev/myproject",
+        ),
+        branch: str | None = discord.Option(
+            default=None,
+            description="Branch to bind (use @name). In channels: base branch; in threads: thread branch.",
         ),
     ) -> None:
-        """Show or clear context binding."""
-        if ctx.guild is None:
-            await ctx.respond(
-                "This command can only be used in a server.", ephemeral=True
-            )
-            return
-
-        guild_id = ctx.guild.id
-        channel_id = ctx.channel_id
-
-        if action == "clear":
-            if not await _require_admin(ctx):
-                return
-            await state_store.set_context(guild_id, channel_id, None)
-            await ctx.respond("Context binding cleared.", ephemeral=True)
-            return
-
-        # Show context
-        from .types import DiscordThreadContext
-
-        context = await state_store.get_context(guild_id, channel_id)
-        if context is None:
-            await ctx.respond(
-                "No context bound to this channel/thread.\n"
-                "Use `/bind <project>` to set up this channel.",
-                ephemeral=True,
-            )
-            return
-
-        if isinstance(context, DiscordThreadContext):
-            msg = (
-                f"**Context**\n"
-                f"- Project: `{context.project}`\n"
-                f"- Branch: `{context.branch}`\n"
-                f"- Engine: `{context.default_engine}`"
-            )
-        else:
-            msg = (
-                f"**Context**\n"
-                f"- Project: `{context.project}`\n"
-                f"- Default branch: `{context.worktree_base}`\n"
-                f"- Engine: `{context.default_engine}`"
-            )
-        await ctx.respond(msg, ephemeral=True)
+        """Show/clear/set context binding."""
+        await _handle_ctx_command(
+            ctx,
+            action=action,
+            project=project,
+            branch=branch,
+            state_store=state_store,
+        )
 
     @pycord_bot.slash_command(
         name="agent", description="Show available agents and current defaults"

--- a/tests/test_ctx_command.py
+++ b/tests/test_ctx_command.py
@@ -1,0 +1,221 @@
+"""Tests for /ctx command handler."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from takopi_discord.types import DiscordChannelContext, DiscordThreadContext
+
+
+class DummyThread:
+    """Minimal stand-in for discord.Thread for unit tests."""
+
+    def __init__(self, *, parent_id: int | None) -> None:
+        self.parent_id = parent_id
+
+
+@pytest.mark.anyio
+async def test_ctx_show_in_thread_reports_bound_and_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import takopi_discord.handlers as handlers
+
+    monkeypatch.setattr(handlers.discord, "Thread", DummyThread)
+
+    ctx = MagicMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = 1
+    ctx.channel_id = 10  # thread id
+    ctx.channel = DummyThread(parent_id=20)  # parent channel id
+    ctx.respond = AsyncMock()
+
+    channel_ctx = DiscordChannelContext(
+        project="/repo",
+        worktrees_dir=".worktrees",
+        default_engine="claude",
+        worktree_base="main",
+    )
+    thread_ctx = DiscordThreadContext(
+        project="/repo",
+        branch="feat-1",
+        worktrees_dir=".worktrees",
+        default_engine="codex",
+    )
+
+    async def get_context(_guild_id: int, channel_id: int):
+        if channel_id == 10:
+            return thread_ctx
+        if channel_id == 20:
+            return channel_ctx
+        return None
+
+    state_store = MagicMock()
+    state_store.get_context = AsyncMock(side_effect=get_context)
+    state_store.set_context = AsyncMock()
+
+    await handlers._handle_ctx_command(
+        ctx,
+        action=None,
+        project=None,
+        branch=None,
+        state_store=state_store,
+    )
+
+    args, kwargs = ctx.respond.call_args
+    content = args[0] if args else kwargs["content"]
+    assert "**Resolved**" in content
+    assert "`/repo`" in content
+    assert "`feat-1`" in content
+    assert "`codex`" in content
+    assert "**Bound**" in content
+
+
+@pytest.mark.anyio
+async def test_ctx_show_in_thread_falls_back_to_channel_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import takopi_discord.handlers as handlers
+
+    monkeypatch.setattr(handlers.discord, "Thread", DummyThread)
+
+    ctx = MagicMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = 1
+    ctx.channel_id = 10  # thread id
+    ctx.channel = DummyThread(parent_id=20)  # parent channel id
+    ctx.respond = AsyncMock()
+
+    channel_ctx = DiscordChannelContext(
+        project="/repo",
+        worktrees_dir=".worktrees",
+        default_engine="claude",
+        worktree_base="main",
+    )
+
+    async def get_context(_guild_id: int, channel_id: int):
+        if channel_id == 10:
+            return None
+        if channel_id == 20:
+            return channel_ctx
+        return None
+
+    state_store = MagicMock()
+    state_store.get_context = AsyncMock(side_effect=get_context)
+    state_store.set_context = AsyncMock()
+
+    await handlers._handle_ctx_command(
+        ctx,
+        action="show",
+        project=None,
+        branch=None,
+        state_store=state_store,
+    )
+
+    args, kwargs = ctx.respond.call_args
+    content = args[0] if args else kwargs["content"]
+    assert "`/repo`" in content
+    assert "`main`" in content
+    assert "Source: channel" in content
+
+
+@pytest.mark.anyio
+async def test_ctx_set_in_thread_rebinds_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import takopi_discord.handlers as handlers
+
+    monkeypatch.setattr(handlers.discord, "Thread", DummyThread)
+    monkeypatch.setattr(handlers, "_require_admin", AsyncMock(return_value=True))
+
+    ctx = MagicMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = 1
+    ctx.channel_id = 10  # thread id
+    ctx.channel = DummyThread(parent_id=20)  # parent channel id
+    ctx.respond = AsyncMock()
+
+    channel_ctx = DiscordChannelContext(
+        project="/repo",
+        worktrees_dir=".worktrees",
+        default_engine="claude",
+        worktree_base="main",
+    )
+
+    async def get_context(_guild_id: int, channel_id: int):
+        if channel_id == 10:
+            return None
+        if channel_id == 20:
+            return channel_ctx
+        return None
+
+    state_store = MagicMock()
+    state_store.get_context = AsyncMock(side_effect=get_context)
+    state_store.set_context = AsyncMock()
+
+    await handlers._handle_ctx_command(
+        ctx,
+        action="set",
+        project=None,
+        branch="@feature/new",
+        state_store=state_store,
+    )
+
+    state_store.set_context.assert_awaited_once_with(
+        1,
+        10,
+        DiscordThreadContext(
+            project="/repo",
+            branch="feature/new",
+            worktrees_dir=".worktrees",
+            default_engine="claude",
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_ctx_set_in_channel_updates_project_and_base_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import takopi_discord.handlers as handlers
+
+    monkeypatch.setattr(handlers.discord, "Thread", DummyThread)
+    monkeypatch.setattr(handlers, "_require_admin", AsyncMock(return_value=True))
+
+    ctx = MagicMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = 1
+    ctx.channel_id = 20  # channel id
+    ctx.channel = MagicMock()
+    ctx.respond = AsyncMock()
+
+    existing = DiscordChannelContext(
+        project="/old",
+        worktrees_dir=".wt",
+        default_engine="codex",
+        worktree_base="main",
+    )
+
+    state_store = MagicMock()
+    state_store.get_context = AsyncMock(return_value=existing)
+    state_store.set_context = AsyncMock()
+
+    await handlers._handle_ctx_command(
+        ctx,
+        action="set",
+        project="/new",
+        branch="@dev",
+        state_store=state_store,
+    )
+
+    state_store.set_context.assert_awaited_once_with(
+        1,
+        20,
+        DiscordChannelContext(
+            project="/new",
+            worktrees_dir=".wt",
+            default_engine="codex",
+            worktree_base="dev",
+        ),
+    )


### PR DESCRIPTION
Fixes #43.

- Add `/ctx set` for channels (`<project>` + optional `@base-branch`) and threads (`@branch`).
- Update `/ctx show` to display bound vs resolved context (thread falls back to parent channel).
- Keep `/ctx clear` semantics; admin-gated changes.

Tests: `tests/test_ctx_command.py`.
