### PR TITLE
Discord: transcribe voice message attachments

### DIFF
--- a/src/takopi_discord/backend.py
+++ b/src/takopi_discord/backend.py
@@ -19,6 +19,7 @@ from .bridge import (
     DiscordFilesSettings,
     DiscordPresenter,
     DiscordTransport,
+    DiscordVoiceMessageSettings,
 )
 from .client import DiscordBotClient
 from .loop import run_main_loop
@@ -144,6 +145,14 @@ class DiscordBackend(TransportBackend):
             ),
         )
 
+        # Parse voice message transcription settings
+        voice_settings = settings.get("voice_messages", {})
+        voice_messages_config = DiscordVoiceMessageSettings(
+            enabled=voice_settings.get("enabled", False),
+            max_bytes=voice_settings.get("max_bytes", 10 * 1024 * 1024),
+            whisper_model=voice_settings.get("whisper_model", "base"),
+        )
+
         startup_msg = _build_startup_message(
             runtime,
             startup_pwd=os.getcwd(),
@@ -168,6 +177,7 @@ class DiscordBackend(TransportBackend):
             message_overflow=message_overflow,
             trigger_mode_default=trigger_mode_default,
             files=files_config,
+            voice_messages=voice_messages_config,
         )
 
         async def run_loop() -> None:

--- a/src/takopi_discord/bridge.py
+++ b/src/takopi_discord/bridge.py
@@ -24,6 +24,7 @@ __all__ = [
     "DiscordFilesSettings",
     "DiscordPresenter",
     "DiscordTransport",
+    "DiscordVoiceMessageSettings",
 ]
 
 CANCEL_BUTTON_ID = "takopi-discord:cancel"
@@ -140,6 +141,15 @@ class DiscordFilesSettings:
 
 
 @dataclass(frozen=True, slots=True)
+class DiscordVoiceMessageSettings:
+    """Settings for voice message attachment transcription in text chat."""
+
+    enabled: bool = False
+    max_bytes: int = 10 * 1024 * 1024  # 10MB
+    whisper_model: str = "base"
+
+
+@dataclass(frozen=True, slots=True)
 class DiscordBridgeConfig:
     """Configuration for the Discord bridge."""
 
@@ -153,6 +163,7 @@ class DiscordBridgeConfig:
     message_overflow: Literal["trim", "split"] = "split"
     trigger_mode_default: Literal["all", "mentions"] = "all"
     files: DiscordFilesSettings = DiscordFilesSettings()
+    voice_messages: DiscordVoiceMessageSettings = DiscordVoiceMessageSettings()
 
 
 # Type alias for message listener callbacks

--- a/src/takopi_discord/loop.py
+++ b/src/takopi_discord/loop.py
@@ -38,6 +38,7 @@ from .prefs import DiscordPrefsStore
 from .render import prepare_discord
 from .state import DiscordStateStore
 from .types import DiscordChannelContext, DiscordThreadContext
+from .voice_messages import WhisperAttachmentTranscriber, is_audio_attachment
 
 if TYPE_CHECKING:
     from takopi.context import RunContext
@@ -425,11 +426,24 @@ async def run_main_loop(
     else:
         logger.info("voice.disabled", reason="OPENAI_API_KEY not set (needed for TTS)")
 
+    voice_attachment_transcriber: WhisperAttachmentTranscriber | None = None
+    if cfg.voice_messages.enabled:
+        whisper_model = os.environ.get(
+            "WHISPER_MODEL", cfg.voice_messages.whisper_model
+        )
+        voice_attachment_transcriber = WhisperAttachmentTranscriber(whisper_model)
+        logger.info(
+            "voice_messages.enabled",
+            whisper_model=whisper_model,
+            max_bytes=cfg.voice_messages.max_bytes,
+        )
+
     logger.info(
         "loop.config",
         has_state_store=state_store is not None,
         guild_id=cfg.guild_id,
         voice_enabled=voice_manager is not None,
+        voice_messages_enabled=cfg.voice_messages.enabled,
     )
 
     def get_running_task(channel_id: int) -> int | None:
@@ -928,9 +942,72 @@ async def run_main_loop(
             if branch_override:
                 logger.info("branch.override", branch=branch_override)
 
+        attachments_for_files = list(message.attachments)
+        audio_attachments = [
+            attachment
+            for attachment in attachments_for_files
+            if is_audio_attachment(attachment)
+        ]
+        non_audio_attachments = [
+            attachment
+            for attachment in attachments_for_files
+            if not is_audio_attachment(attachment)
+        ]
+
+        if audio_attachments and not prompt.strip() and voice_attachment_transcriber:
+            attachment = audio_attachments[0]
+            if attachment.size > cfg.voice_messages.max_bytes:
+                await message.reply(
+                    "Voice message is too large to transcribe.\n"
+                    f"- Size: {attachment.size} bytes\n"
+                    f"- Max: {cfg.voice_messages.max_bytes} bytes",
+                    mention_author=False,
+                )
+                return
+
+            try:
+                payload = await attachment.read()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "voice_messages.read_failed",
+                    filename=attachment.filename,
+                    error=str(exc),
+                    error_type=exc.__class__.__name__,
+                )
+                return
+
+            transcript = await voice_attachment_transcriber.transcribe_bytes(
+                payload,
+                suffix=Path(attachment.filename or "voice.bin").suffix or ".bin",
+            )
+            if not transcript.strip():
+                await message.reply(
+                    "Couldn't transcribe that voice message.", mention_author=False
+                )
+                return
+
+            logger.info(
+                "voice_messages.transcribed",
+                message_id=message.id,
+                filename=attachment.filename,
+                transcript_length=len(transcript),
+            )
+            prompt = transcript
+            attachments_for_files = non_audio_attachments
+
         # Allow empty prompt if @branch was used or if there are attachments (for auto_put)
         has_attachments = bool(message.attachments)
         if not prompt.strip() and not branch_override and not has_attachments:
+            return
+
+        if (
+            audio_attachments
+            and not non_audio_attachments
+            and not prompt.strip()
+            and branch_override is None
+            and not cfg.voice_messages.enabled
+        ):
+            logger.debug("voice_messages.ignored", reason="disabled")
             return
 
         # Apply branch override to context
@@ -1120,7 +1197,7 @@ async def run_main_loop(
         ):
             author_id = getattr(message.author, "id", None)
             if isinstance(author_id, int):
-                if message.attachments and not prompt.strip():
+                if attachments_for_files and not prompt.strip():
                     media_buffer.add(
                         message,
                         prompt="",
@@ -1137,12 +1214,12 @@ async def run_main_loop(
                         thread_id=thread_id,
                         author_id=author_id,
                         message_id=message.id,
-                        attachment_count=len(message.attachments),
+                        attachment_count=len(attachments_for_files),
                     )
                     return
                 if (
                     prompt.strip()
-                    and not message.attachments
+                    and not attachments_for_files
                     and media_buffer.has_pending(
                         channel_id=thread_id, author_id=author_id
                     )
@@ -1172,9 +1249,9 @@ async def run_main_loop(
             "auto_put.check",
             files_enabled=cfg.files.enabled,
             auto_put=cfg.files.auto_put,
-            attachment_count=len(message.attachments),
+            attachment_count=len(attachments_for_files),
         )
-        if cfg.files.enabled and cfg.files.auto_put and message.attachments:
+        if cfg.files.enabled and cfg.files.auto_put and attachments_for_files:
             from takopi.config import ConfigError
 
             from .file_transfer import format_bytes, save_attachment
@@ -1184,7 +1261,7 @@ async def run_main_loop(
                 logger.debug(
                     "auto_put.skipped",
                     reason="no project context",
-                    attachment_count=len(message.attachments),
+                    attachment_count=len(attachments_for_files),
                 )
             else:
                 try:
@@ -1197,7 +1274,7 @@ async def run_main_loop(
                     file_annotations: list[str] = []
                     saved_files: list[str] = []
 
-                    for attachment in message.attachments:
+                    for attachment in attachments_for_files:
                         result = await save_attachment(
                             attachment,
                             run_root,

--- a/src/takopi_discord/voice_messages.py
+++ b/src/takopi_discord/voice_messages.py
@@ -1,0 +1,139 @@
+"""Voice message attachment transcription helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import re
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pywhispercpp.model import Model as WhisperModel
+
+if TYPE_CHECKING:
+    import discord
+
+logger = logging.getLogger("takopi.discord.voice_messages")
+
+WHISPER_SAMPLE_RATE = 16000
+
+_AUDIO_EXTENSIONS = (
+    ".aac",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".webm",
+)
+
+
+def is_audio_attachment(attachment: discord.Attachment) -> bool:
+    """Return True when the attachment looks like an audio file/voice message."""
+    content_type = getattr(attachment, "content_type", None)
+    if isinstance(content_type, str) and content_type.startswith("audio/"):
+        return True
+
+    filename = getattr(attachment, "filename", None)
+    if not isinstance(filename, str) or not filename:
+        return False
+    suffix = Path(filename).suffix.lower()
+    return suffix in _AUDIO_EXTENSIONS
+
+
+def _combine_whisper_segments(segments: Iterable[object]) -> str:
+    segments_list = list(segments)
+    if not segments_list:
+        return ""
+
+    cleaned_segments: list[str] = []
+    for seg in segments_list:
+        seg_text = getattr(seg, "text", "")
+        if not isinstance(seg_text, str):
+            continue
+        seg_text = seg_text.strip()
+        if not seg_text:
+            continue
+        # Skip segments that are only artifacts like [Silence] or (BLANK_AUDIO)
+        if re.fullmatch(r"[\[\(].*?[\]\)]", seg_text):
+            continue
+        cleaned_segments.append(seg_text)
+
+    text = " ".join(cleaned_segments)
+    text = re.sub(r"\[.*?\]", "", text)  # Remove [bracketed] text
+    text = re.sub(r"\(.*?\)", "", text)  # Remove (parenthesized) text
+    text = re.sub(r"\s+", " ", text)  # Normalize whitespace
+    return text.strip()
+
+
+class WhisperAttachmentTranscriber:
+    """Transcribes audio attachments using local Whisper (pywhispercpp)."""
+
+    def __init__(self, model_name: str) -> None:
+        self._model_name = model_name
+        self._model: WhisperModel | None = None
+        self._lock = asyncio.Lock()
+
+    def _get_whisper_model(self) -> WhisperModel:
+        if self._model is None:
+            logger.info("Loading Whisper model: %s", self._model_name)
+            self._model = WhisperModel(self._model_name)
+            logger.info("Whisper model loaded")
+        return self._model
+
+    def _transcribe_sync(self, payload: bytes, *, suffix: str) -> str:
+        model = self._get_whisper_model()
+
+        in_path: Path | None = None
+        wav_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+                handle.write(payload)
+                in_path = Path(handle.name)
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as handle:
+                wav_path = Path(handle.name)
+
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    str(in_path),
+                    "-ar",
+                    str(WHISPER_SAMPLE_RATE),
+                    "-ac",
+                    "1",
+                    "-f",
+                    "wav",
+                    str(wav_path),
+                ],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.decode(errors="replace")
+                logger.warning("ffmpeg.convert_failed", stderr=stderr[:500])
+                return ""
+
+            segments = model.transcribe(str(wav_path))
+            return _combine_whisper_segments(segments)
+        finally:
+            if in_path is not None:
+                with contextlib.suppress(OSError):
+                    in_path.unlink()
+            if wav_path is not None:
+                with contextlib.suppress(OSError):
+                    wav_path.unlink()
+
+    async def transcribe_bytes(self, payload: bytes, *, suffix: str) -> str:
+        """Transcribe audio bytes into text."""
+        if not payload:
+            return ""
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._transcribe_sync, payload, suffix=suffix
+            )

--- a/tests/test_voice_messages.py
+++ b/tests/test_voice_messages.py
@@ -1,0 +1,74 @@
+"""Tests for voice message transcription helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+import takopi_discord.voice_messages as voice_messages
+
+
+def test_is_audio_attachment_detects_by_content_type() -> None:
+    attachment = MagicMock()
+    attachment.content_type = "audio/ogg"
+    attachment.filename = "voice.ogg"
+    assert voice_messages.is_audio_attachment(attachment) is True
+
+
+def test_is_audio_attachment_detects_by_extension() -> None:
+    attachment = MagicMock()
+    attachment.content_type = None
+    attachment.filename = "clip.MP3"
+    assert voice_messages.is_audio_attachment(attachment) is True
+
+
+def test_is_audio_attachment_rejects_unknown() -> None:
+    attachment = MagicMock()
+    attachment.content_type = "image/png"
+    attachment.filename = "image.png"
+    assert voice_messages.is_audio_attachment(attachment) is False
+
+
+@dataclass(frozen=True, slots=True)
+class _Seg:
+    text: str
+
+
+@pytest.mark.anyio
+async def test_transcriber_cleans_whisper_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, capture_output: bool):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+            stderr = b""
+
+        return Result()
+
+    class DummyModel:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def transcribe(self, _path: str):
+            return [
+                _Seg(text="[Silence]"),
+                _Seg(text=" hello "),
+                _Seg(text="(Music)"),
+                _Seg(text="world"),
+            ]
+
+    monkeypatch.setattr(voice_messages, "WhisperModel", DummyModel)
+    monkeypatch.setattr(voice_messages.subprocess, "run", fake_run)
+
+    transcriber = voice_messages.WhisperAttachmentTranscriber("base")
+    text = await transcriber.transcribe_bytes(b"123", suffix=".ogg")
+
+    assert text == "hello world"
+    assert calls
+    assert "ffmpeg" in calls[0][0]


### PR DESCRIPTION
Fixes #45.

- Add optional `voice_messages` transport config (`enabled`, `max_bytes`, `whisper_model`).
- When enabled, audio/voice-message attachments posted with no text are transcribed via local Whisper and routed like typed prompts.
- When disabled, audio-only messages are ignored (no empty-thread creation).
- Transcribed audio attachments are excluded from `/files` auto_put handling.

Config example:
```yaml
transports:
  discord:
    voice_messages:
      enabled: true
      max_bytes: 10485760
      whisper_model: base
```

Tests: `tests/test_voice_messages.py`.
