### PR TITLE
Discord: configurable media group debounce

### DIFF
--- a/src/takopi_discord/backend.py
+++ b/src/takopi_discord/backend.py
@@ -128,6 +128,24 @@ class DiscordBackend(TransportBackend):
             Literal["all", "mentions"], trigger_mode_default_normalized
         )
 
+        media_group_debounce_s_raw = settings.get("media_group_debounce_s", 0.75)
+        try:
+            media_group_debounce_s = float(media_group_debounce_s_raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "config.invalid_media_group_debounce_s",
+                value=media_group_debounce_s_raw,
+                fallback=0.75,
+            )
+            media_group_debounce_s = 0.75
+        if media_group_debounce_s < 0:
+            logger.warning(
+                "config.invalid_media_group_debounce_s",
+                value=media_group_debounce_s_raw,
+                fallback=0.75,
+            )
+            media_group_debounce_s = 0.75
+
         # Parse files settings
         files_settings = settings.get("files", {})
         files_config = DiscordFilesSettings(
@@ -168,6 +186,7 @@ class DiscordBackend(TransportBackend):
             message_overflow=message_overflow,
             trigger_mode_default=trigger_mode_default,
             files=files_config,
+            media_group_debounce_s=media_group_debounce_s,
         )
 
         async def run_loop() -> None:

--- a/src/takopi_discord/bridge.py
+++ b/src/takopi_discord/bridge.py
@@ -153,6 +153,7 @@ class DiscordBridgeConfig:
     message_overflow: Literal["trim", "split"] = "split"
     trigger_mode_default: Literal["all", "mentions"] = "all"
     files: DiscordFilesSettings = DiscordFilesSettings()
+    media_group_debounce_s: float = 0.75
 
 
 # Type alias for message listener callbacks

--- a/src/takopi_discord/loop.py
+++ b/src/takopi_discord/loop.py
@@ -1599,11 +1599,14 @@ async def run_main_loop(
                 running_tasks=running_tasks,
                 enqueue_resume=scheduler.enqueue_resume,
             )
-            media_buffer = MediaGroupBuffer(
-                task_group=tg,
-                debounce_s=0.75,
-                dispatch=dispatch_media_group,
-            )
+            if cfg.media_group_debounce_s > 0:
+                media_buffer = MediaGroupBuffer(
+                    task_group=tg,
+                    debounce_s=cfg.media_group_debounce_s,
+                    dispatch=dispatch_media_group,
+                )
+            else:
+                media_buffer = None
 
             # Start the bot
             await cfg.bot.start()

--- a/tests/test_media_group_buffer.py
+++ b/tests/test_media_group_buffer.py
@@ -1,0 +1,86 @@
+"""Tests for attachment media-group buffering."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+
+from takopi_discord.loop import MediaGroupBuffer
+
+
+class _ControlledSleep:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+        self.events: list[anyio.Event] = []
+
+    async def __call__(self, duration: float) -> None:
+        self.calls.append(duration)
+        event = anyio.Event()
+        self.events.append(event)
+        await event.wait()
+
+
+@pytest.mark.anyio
+async def test_media_group_buffer_coalesces_multiple_adds() -> None:
+    dispatched: list[object] = []
+    dispatched_event = anyio.Event()
+
+    async def dispatch(state) -> None:
+        dispatched.append(state)
+        dispatched_event.set()
+
+    sleep = _ControlledSleep()
+
+    async with anyio.create_task_group() as tg:
+        buffer = MediaGroupBuffer(
+            task_group=tg,
+            debounce_s=0.75,
+            dispatch=dispatch,
+            sleep=sleep,
+        )
+
+        msg1 = MagicMock()
+        msg1.author = MagicMock()
+        msg1.author.id = 123
+        buffer.add(
+            msg1,
+            prompt="",
+            guild_id=1,
+            channel_id=2,
+            thread_id=3,
+            job_channel_id=3,
+            engine_id="claude",
+            resume_token=None,
+            context=None,
+        )
+
+        while not sleep.events:
+            await anyio.sleep(0)
+
+        msg2 = MagicMock()
+        msg2.author = MagicMock()
+        msg2.author.id = 123
+        buffer.add(
+            msg2,
+            prompt="caption",
+            guild_id=1,
+            channel_id=2,
+            thread_id=3,
+            job_channel_id=3,
+            engine_id="claude",
+            resume_token=None,
+            context=None,
+        )
+
+        sleep.events[0].set()
+        while len(sleep.events) < 2:
+            await anyio.sleep(0)
+        sleep.events[1].set()
+
+        await dispatched_event.wait()
+
+    assert len(dispatched) == 1
+    state = dispatched[0]
+    assert len(state.items) == 2


### PR DESCRIPTION
Fixes #46.

- Add `transports.discord.media_group_debounce_s` (float >= 0; default `0.75`).
- Set to `0` to disable attachment media-group buffering.
- Wire through `DiscordBridgeConfig.media_group_debounce_s` into `MediaGroupBuffer` creation.

Tests: `tests/test_media_group_buffer.py`.
