### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-02-25
+
+### Added
+- Per-user session isolation when `session_mode = "chat"`
+- Resume token extraction from replies to bot progress messages
+- Discord allowlist gating via `transports.discord.allowed_user_ids`
+- `/ctx set` for rebinding channel/thread context
+- `/agent set|clear` for per-channel/thread default agent overrides
+- `/file put` for uploading attachments to explicit paths
+- Voice message attachment transcription via `transports.discord.voice_messages`
+- Configurable media group debounce via `transports.discord.media_group_debounce_s`
+
+### Changed
+- File transfer configuration is now under `transports.discord.files` (enable with `files.enabled = true`)
+
 ## [0.4.1] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,7 +54,22 @@ message_overflow = "split"       # "split" (default) or "trim" for long messages
 session_mode = "stateless"       # "stateless" (default) or "chat"
 show_resume_line = true          # Show resume token in messages (default: true)
 trigger_mode_default = "all"     # "all" (default) or "mentions" for inherited trigger mode
-upload_dir = "~/uploads"         # Optional: enable /file commands with this root dir
+# allowed_user_ids = [123456789012345678]  # Optional: restrict bot usage (Discord user IDs)
+media_group_debounce_s = 0.75     # Buffer bursts of attachments (seconds)
+
+[transports.discord.files]
+enabled = false                  # Enable /file + attachment auto-upload
+# auto_put = true                # Auto-save attachments into `uploads_dir`
+# auto_put_mode = "upload"       # "upload" (default) or "prompt"
+uploads_dir = "incoming"         # Relative path in the repo
+# max_upload_bytes = 20971520    # 20MB
+# deny_globs = [".git/**", ".env", ".envrc", "**/*.pem", "**/.ssh/**"]
+# allowed_user_ids = [123456789012345678]  # Optional: restrict file transfers separately
+
+[transports.discord.voice_messages]
+enabled = false                  # Transcribe audio attachments with no text prompt
+# max_bytes = 10485760           # 10MB
+whisper_model = "base"
 ```
 
 State is automatically saved to `~/.takopi/discord_state.json`. Chat preferences
@@ -86,7 +101,7 @@ State is automatically saved to `~/.takopi/discord_state.json`. Chat preferences
 - `/bind <project> [worktrees_dir] [default_engine] [worktree_base]` - Bind channel to a project
 - `/unbind` - Remove project binding
 - `/status` - Show current channel/thread context and status
-- `/ctx [show|clear]` - Show or clear context binding
+- `/ctx [show|set|clear]` - Show or modify context binding
 - `/cancel` - Cancel running task
 - `/new` - Clear conversation session (start fresh)
 
@@ -103,7 +118,7 @@ These commands allow you to target a specific engine regardless of the channel's
 
 ### Agent & Model Commands
 
-- `/agent` - Show available agents and current defaults
+- `/agent [show|set|clear] [engine]` - Show or override the default agent for this channel/thread
 - `/model [engine] [model]` - Show or set model override for an engine
 - `/reasoning [engine] [level]` - Show or set reasoning level (minimal/low/medium/high/xhigh)
 - `/trigger [all|mentions|clear]` - Set when bot responds (all messages or only @mentions)
@@ -113,13 +128,15 @@ These commands allow you to target a specific engine regardless of the channel's
 - `/file get <path>` - Download a file or directory (zipped) from the server
 - `/file put <path>` - Upload a file (attach file, then reply with this command)
 
-Requires `upload_dir` to be configured. Files in `.git`, `.env`, and credentials are blocked.
+Enable with `[transports.discord.files] enabled = true`. Files in `.git`, `.env`, and credentials are blocked.
 
 ### Voice
 
 - `/voice` or `/vc` - Create a voice channel for the current thread/channel
 
 The voice channel is bound to the project context and auto-deletes when empty. Uses local Whisper for speech-to-text transcription.
+
+To transcribe voice message attachments in text chat, enable `[transports.discord.voice_messages]` (requires `ffmpeg`).
 
 ### Plugins
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "takopi-discord"
 authors = [{name = "ayvee"}]
-version = "0.4.1"
+version = "0.5.0"
 description = "Discord transport plugin for takopi"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/takopi_discord/__init__.py
+++ b/src/takopi_discord/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 from .backend import BACKEND
 

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ wheels = [
 
 [[package]]
 name = "takopi-discord"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
Prepares the v0.5.0 release (CHANGELOG, README, version bump).

- [x] uv sync --frozen
- [x] ruff format/check
- [x] pytest
- [x] uv build

After merge: tag and push `v0.5.0` to trigger the PyPI + GitHub Release workflow.