### PR TITLE
fix: allow trusted bot senders in discord threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ message_overflow = "split"       # "split" (default) or "trim" for long messages
 session_mode = "stateless"       # "stateless" (default) or "chat"
 show_resume_line = true          # Show resume token in messages (default: true)
 trigger_mode_default = "all"     # "all" (default) or "mentions" for inherited trigger mode
-# allowed_user_ids = [123456789012345678]  # Optional: restrict bot usage (Discord user IDs)
+# allowed_user_ids = [123456789012345678]      # Optional: restrict human bot usage (Discord user IDs)
+# allowed_bot_user_ids = [987654321098765432]  # Optional: trusted bot senders allowed to trigger Takopi
 media_group_debounce_s = 0.75     # Buffer bursts of attachments (seconds)
 
 [transports.discord.files]

--- a/src/takopi_discord/backend.py
+++ b/src/takopi_discord/backend.py
@@ -138,6 +138,14 @@ class DiscordBackend(TransportBackend):
                 value=allowed_user_ids_raw,
             )
 
+        allowed_bot_user_ids_raw = settings.get("allowed_bot_user_ids")
+        allowed_bot_user_ids = normalize_user_id_set(allowed_bot_user_ids_raw)
+        if allowed_bot_user_ids_raw and allowed_bot_user_ids is None:
+            logger.warning(
+                "config.invalid_allowed_bot_user_ids",
+                value=allowed_bot_user_ids_raw,
+            )
+
         media_group_debounce_s_raw = settings.get("media_group_debounce_s", 0.75)
         try:
             media_group_debounce_s = float(media_group_debounce_s_raw)
@@ -206,6 +214,7 @@ class DiscordBackend(TransportBackend):
             runtime=runtime,
             guild_id=guild_id,
             allowed_user_ids=allowed_user_ids,
+            allowed_bot_user_ids=allowed_bot_user_ids,
             startup_msg=startup_msg,
             exec_cfg=exec_cfg,
             session_mode=session_mode,

--- a/src/takopi_discord/bridge.py
+++ b/src/takopi_discord/bridge.py
@@ -160,6 +160,7 @@ class DiscordBridgeConfig:
     startup_msg: str
     exec_cfg: ExecBridgeConfig
     allowed_user_ids: frozenset[int] | None = None
+    allowed_bot_user_ids: frozenset[int] | None = None
     session_mode: Literal["stateless", "chat"] = "stateless"
     show_resume_line: bool = True
     message_overflow: Literal["trim", "split"] = "split"

--- a/src/takopi_discord/handlers.py
+++ b/src/takopi_discord/handlers.py
@@ -1566,6 +1566,7 @@ def should_process_message(
     bot_user: discord.User | None,
     *,
     require_mention: bool = False,
+    allowed_bot_user_ids: frozenset[int] | None = None,
 ) -> bool:
     """Determine if a message should be processed by the bot.
 
@@ -1573,10 +1574,14 @@ def should_process_message(
         message: The Discord message
         bot_user: The bot's user object
         require_mention: If True, only process messages that mention the bot
+        allowed_bot_user_ids: Bot sender IDs that are trusted to bypass the
+            default bot-message ignore rule
     """
-    # Ignore bot messages
+    # Ignore bot messages unless the sender is explicitly allowlisted.
     if message.author.bot:
-        return False
+        author_id = getattr(message.author, "id", None)
+        if not isinstance(author_id, int) or author_id not in (allowed_bot_user_ids or frozenset()):
+            return False
 
     # Ignore empty messages (but allow if there are attachments for auto_put)
     if not message.content.strip() and not message.attachments:

--- a/src/takopi_discord/handlers.py
+++ b/src/takopi_discord/handlers.py
@@ -1580,7 +1580,9 @@ def should_process_message(
     # Ignore bot messages unless the sender is explicitly allowlisted.
     if message.author.bot:
         author_id = getattr(message.author, "id", None)
-        if not isinstance(author_id, int) or author_id not in (allowed_bot_user_ids or frozenset()):
+        if not isinstance(author_id, int) or author_id not in (
+            allowed_bot_user_ids or frozenset()
+        ):
             return False
 
     # Ignore empty messages (but allow if there are attachments for auto_put)

--- a/src/takopi_discord/loop.py
+++ b/src/takopi_discord/loop.py
@@ -873,7 +873,12 @@ async def run_main_loop(
             )
             return
 
-        if not should_process_message(message, cfg.bot.user, require_mention=False):
+        if not should_process_message(
+            message,
+            cfg.bot.user,
+            require_mention=False,
+            allowed_bot_user_ids=cfg.allowed_bot_user_ids,
+        ):
             logger.debug(
                 "message.skipped", reason="should_process_message returned False"
             )

--- a/src/takopi_discord/loop.py
+++ b/src/takopi_discord/loop.py
@@ -73,6 +73,23 @@ def _diff_keys(old: dict[str, Any], new: dict[str, Any]) -> list[str]:
     return sorted(key for key in keys if old.get(key) != new.get(key))
 
 
+def _is_message_author_allowed(
+    *,
+    allowed_user_ids: frozenset[int] | None,
+    allowed_bot_user_ids: frozenset[int] | None,
+    author_id: int | None,
+    author_is_bot: bool,
+) -> bool:
+    if (
+        author_is_bot
+        and author_id is not None
+        and allowed_bot_user_ids is not None
+        and author_id in allowed_bot_user_ids
+    ):
+        return True
+    return is_user_allowed(allowed_user_ids, author_id)
+
+
 async def _save_session_token(
     *,
     state_store: DiscordStateStore | None,
@@ -887,7 +904,12 @@ async def run_main_loop(
         author_id = getattr(message.author, "id", None)
         if not isinstance(author_id, int):
             author_id = None
-        if not is_user_allowed(cfg.allowed_user_ids, author_id):
+        if not _is_message_author_allowed(
+            allowed_user_ids=cfg.allowed_user_ids,
+            allowed_bot_user_ids=cfg.allowed_bot_user_ids,
+            author_id=author_id,
+            author_is_bot=bool(getattr(message.author, "bot", False)),
+        ):
             logger.debug(
                 "message.skipped",
                 reason="not in allowed_user_ids",

--- a/tests/test_backend_allowed_bot_ids.py
+++ b/tests/test_backend_allowed_bot_ids.py
@@ -1,0 +1,52 @@
+"""Tests for Discord backend config parsing of allowed bot senders."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import takopi_discord.backend as backend_module
+
+
+def _runtime_stub(config_path: Path) -> MagicMock:
+    runtime = MagicMock()
+    runtime.available_engine_ids.return_value = ["codex"]
+    runtime.missing_engine_ids.return_value = []
+    runtime.engine_ids_with_status.return_value = []
+    runtime.project_aliases.return_value = []
+    runtime.default_engine = "codex"
+    runtime.config_path = config_path
+    runtime.watch_config = False
+    return runtime
+
+
+def test_build_and_run_parses_allowed_bot_user_ids(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run_main_loop(cfg, **kwargs) -> None:
+        captured["cfg"] = cfg
+        captured["kwargs"] = kwargs
+
+    def fake_anyio_run(fn) -> None:
+        asyncio.run(fn())
+
+    monkeypatch.setattr(backend_module, "run_main_loop", fake_run_main_loop)
+    monkeypatch.setattr(backend_module.anyio, "run", fake_anyio_run)
+
+    transport_config = {
+        "bot_token": "secret",
+        "allowed_bot_user_ids": ["123", 456],
+        "files": {},
+        "voice_messages": {},
+    }
+
+    backend_module.DiscordBackend().build_and_run(
+        transport_config=transport_config,
+        config_path=tmp_path / "config.yaml",
+        runtime=_runtime_stub(tmp_path / "config.yaml"),
+        final_notify=False,
+        default_engine_override=None,
+    )
+
+    assert captured["cfg"].allowed_bot_user_ids == frozenset({123, 456})

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,12 @@
 """Tests for handlers module."""
 
-from takopi_discord.handlers import _format_engine_starter_message, parse_branch_prefix
+from types import SimpleNamespace
+
+from takopi_discord.handlers import (
+    _format_engine_starter_message,
+    parse_branch_prefix,
+    should_process_message,
+)
 
 
 class TestParseBranchPrefix:
@@ -65,6 +71,25 @@ class TestParseBranchPrefix:
         branch, prompt = parse_branch_prefix("@issue-123/fix-bug/v2 do the thing")
         assert branch == "issue-123/fix-bug/v2"
         assert prompt == "do the thing"
+
+
+class TestShouldProcessMessage:
+    def test_allowlisted_bot_sender_is_processed(self) -> None:
+        bot_user = SimpleNamespace(id=999)
+        message = SimpleNamespace(
+            author=SimpleNamespace(bot=True, id=123),
+            content="please merge this",
+            attachments=[],
+            channel=SimpleNamespace(),
+            mentions=[],
+        )
+
+        assert should_process_message(
+            message,
+            bot_user,
+            require_mention=False,
+            allowed_bot_user_ids=frozenset({123}),
+        )
 
 
 class TestFormatEngineStarterMessage:

--- a/tests/test_loop_allowed_bot_ids.py
+++ b/tests/test_loop_allowed_bot_ids.py
@@ -1,0 +1,110 @@
+"""Tests for allowed bot sender wiring in the Discord message loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import takopi_discord.loop as loop_module
+from takopi_discord.bridge import DiscordBridgeConfig, DiscordFilesSettings, DiscordVoiceMessageSettings
+
+
+class _StopLoop(RuntimeError):
+    pass
+
+
+@dataclass
+class _DummyPrefsStore:
+    async def ensure_loaded(self) -> None:
+        return None
+
+
+@dataclass
+class _DummyStateStore:
+    async def get_startup_channel(self, guild_id: int) -> int | None:
+        return None
+
+
+class _DummyBotClient:
+    def __init__(self, message) -> None:
+        self.user = SimpleNamespace(id=999, name="Takopi")
+        self.bot = SimpleNamespace(
+            event=lambda fn: fn,
+            process_application_commands=AsyncMock(),
+            sync_commands=AsyncMock(),
+        )
+        self._message = message
+        self._handler = None
+        self.closed = False
+
+    def set_message_handler(self, handler) -> None:
+        self._handler = handler
+
+    async def start(self) -> None:
+        assert self._handler is not None
+        await self._handler(self._message)
+        raise _StopLoop()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _runtime_stub(config_path: Path) -> MagicMock:
+    runtime = MagicMock()
+    runtime.config_path = config_path
+    runtime.allowlist = None
+    runtime.default_engine = "codex"
+    runtime.watch_config = False
+    runtime.engine_ids = ["codex"]
+    return runtime
+
+
+@pytest.mark.anyio
+async def test_run_main_loop_passes_allowed_bot_user_ids_to_message_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    message = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        created_at=datetime.now(UTC) + timedelta(seconds=1),
+        channel=SimpleNamespace(id=10),
+        author=SimpleNamespace(id=123, bot=True, name="Hermes"),
+        content="please continue",
+        attachments=[],
+    )
+    bot = _DummyBotClient(message)
+
+    monkeypatch.setattr(loop_module, "DiscordStateStore", lambda _path: _DummyStateStore())
+    monkeypatch.setattr(loop_module, "DiscordPrefsStore", lambda _path: _DummyPrefsStore())
+    monkeypatch.setattr(loop_module, "register_slash_commands", lambda *args, **kwargs: None)
+    monkeypatch.setattr(loop_module, "register_engine_commands", lambda *args, **kwargs: set())
+    monkeypatch.setattr(loop_module, "discover_command_ids", lambda _allowlist: set())
+
+    def fake_should_process_message(message, bot_user, *, require_mention=False, allowed_bot_user_ids=None):
+        captured["allowed_bot_user_ids"] = allowed_bot_user_ids
+        return False
+
+    monkeypatch.setattr(loop_module, "should_process_message", fake_should_process_message)
+
+    cfg = DiscordBridgeConfig(
+        bot=bot,
+        runtime=_runtime_stub(tmp_path / "config.toml"),
+        guild_id=None,
+        startup_msg="ready",
+        exec_cfg=SimpleNamespace(transport=SimpleNamespace()),
+        allowed_bot_user_ids=frozenset({123}),
+        files=DiscordFilesSettings(),
+        voice_messages=DiscordVoiceMessageSettings(),
+    )
+
+    with pytest.raises(BaseExceptionGroup):
+        await loop_module.run_main_loop(cfg)
+
+    assert captured["allowed_bot_user_ids"] == frozenset({123})
+    assert bot.closed is True

--- a/tests/test_loop_allowed_bot_ids.py
+++ b/tests/test_loop_allowed_bot_ids.py
@@ -11,7 +11,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import takopi_discord.loop as loop_module
-from takopi_discord.bridge import DiscordBridgeConfig, DiscordFilesSettings, DiscordVoiceMessageSettings
+from takopi_discord.bridge import (
+    DiscordBridgeConfig,
+    DiscordFilesSettings,
+    DiscordVoiceMessageSettings,
+)
+from takopi_discord.loop import _is_message_author_allowed
 
 
 class _StopLoop(RuntimeError):
@@ -62,6 +67,39 @@ def _runtime_stub(config_path: Path) -> MagicMock:
     runtime.watch_config = False
     runtime.engine_ids = ["codex"]
     return runtime
+
+
+def test_allowed_bot_user_ids_bypass_human_allowlist() -> None:
+    assert _is_message_author_allowed(
+        allowed_user_ids=frozenset({456}),
+        allowed_bot_user_ids=frozenset({123}),
+        author_id=123,
+        author_is_bot=True,
+    )
+
+
+def test_untrusted_bot_sender_still_uses_human_allowlist() -> None:
+    assert not _is_message_author_allowed(
+        allowed_user_ids=frozenset({456}),
+        allowed_bot_user_ids=frozenset({789}),
+        author_id=123,
+        author_is_bot=True,
+    )
+
+
+def test_human_sender_still_uses_human_allowlist() -> None:
+    assert _is_message_author_allowed(
+        allowed_user_ids=frozenset({456}),
+        allowed_bot_user_ids=frozenset({123}),
+        author_id=456,
+        author_is_bot=False,
+    )
+    assert not _is_message_author_allowed(
+        allowed_user_ids=frozenset({456}),
+        allowed_bot_user_ids=frozenset({123}),
+        author_id=123,
+        author_is_bot=False,
+    )
 
 
 @pytest.mark.anyio

--- a/tests/test_loop_allowed_bot_ids.py
+++ b/tests/test_loop_allowed_bot_ids.py
@@ -118,17 +118,29 @@ async def test_run_main_loop_passes_allowed_bot_user_ids_to_message_gate(
     )
     bot = _DummyBotClient(message)
 
-    monkeypatch.setattr(loop_module, "DiscordStateStore", lambda _path: _DummyStateStore())
-    monkeypatch.setattr(loop_module, "DiscordPrefsStore", lambda _path: _DummyPrefsStore())
-    monkeypatch.setattr(loop_module, "register_slash_commands", lambda *args, **kwargs: None)
-    monkeypatch.setattr(loop_module, "register_engine_commands", lambda *args, **kwargs: set())
+    monkeypatch.setattr(
+        loop_module, "DiscordStateStore", lambda _path: _DummyStateStore()
+    )
+    monkeypatch.setattr(
+        loop_module, "DiscordPrefsStore", lambda _path: _DummyPrefsStore()
+    )
+    monkeypatch.setattr(
+        loop_module, "register_slash_commands", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        loop_module, "register_engine_commands", lambda *args, **kwargs: set()
+    )
     monkeypatch.setattr(loop_module, "discover_command_ids", lambda _allowlist: set())
 
-    def fake_should_process_message(message, bot_user, *, require_mention=False, allowed_bot_user_ids=None):
+    def fake_should_process_message(
+        message, bot_user, *, require_mention=False, allowed_bot_user_ids=None
+    ):
         captured["allowed_bot_user_ids"] = allowed_bot_user_ids
         return False
 
-    monkeypatch.setattr(loop_module, "should_process_message", fake_should_process_message)
+    monkeypatch.setattr(
+        loop_module, "should_process_message", fake_should_process_message
+    )
 
     cfg = DiscordBridgeConfig(
         bot=bot,


### PR DESCRIPTION
## Summary
- add `allowed_bot_user_ids` as an explicit Discord transport config option
- allow trusted bot-authored Discord messages through the message gate when their sender ID is allowlisted
- thread the new allowlist through backend config parsing and the live message loop
- document the new config option in the README
- add regression coverage for helper behavior, backend parsing, and loop wiring

## Why
Takopi was hard-blocking *all* bot-authored Discord messages before checking any allowlist. That meant Hermes-origin thread messages were dropped unconditionally, even after sender approval. This patch keeps the default safe behavior for bots, but adds a narrow escape hatch for explicitly trusted bot sender IDs.

## Test Plan
- `uv run pytest /tmp/takopi-discord/tests/test_handlers.py::TestShouldProcessMessage::test_allowlisted_bot_sender_is_processed -q`
- `uv run pytest /tmp/takopi-discord/tests/test_backend_allowed_bot_ids.py -q`
- `uv run pytest /tmp/takopi-discord/tests/test_loop_allowed_bot_ids.py -q`
- `uv run pytest -q`
- `uv run python - <<'PY' ...` smoke check returned:
  - `trusted_allowlisted: True`
  - `untrusted_blocked: False`
