### PR TITLE
Fix Kimi secret mapping for upstream automation

### DIFF
--- a/.github/workflows/upstream-takopi.yml
+++ b/.github/workflows/upstream-takopi.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Analyze upstream Takopi
         env:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY || secrets.KIMI_API_KEY }}
           FLUE_MODEL: ${{ vars.FLUE_MODEL || 'moonshotai/kimi-k2.6' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run upstream:takopi -- --target node --id takopi-upstream --payload "$(cat /tmp/upstream-takopi-payload.json)"


### PR DESCRIPTION
## Summary
- export MOONSHOT_API_KEY from MOONSHOT_API_KEY when present, otherwise KIMI_API_KEY
- keeps the default direct Moonshot model moonshotai/kimi-k2.6 working with the existing KIMI_API_KEY repo secret

## Verification
- git diff --check

## Context
The dry-run workflow reached the Flue agent but failed with: No API key for provider: moonshotai.