### PR TITLE
Default upstream automation to Kimi Coding

### DIFF
--- a/.flue/agents/upstream-takopi.ts
+++ b/.flue/agents/upstream-takopi.ts
@@ -12,7 +12,7 @@ export const triggers = {};
 
 const TRACKING_LABEL = "upstream-takopi";
 const AGENT_LABEL = "agent-triage";
-const DEFAULT_MODEL = "moonshotai/kimi-k2.6";
+const DEFAULT_MODEL = "kimi-coding/kimi-for-coding";
 
 const analysisSchema = v.object({
   relevant: v.boolean(),

--- a/.github/workflows/upstream-takopi.yml
+++ b/.github/workflows/upstream-takopi.yml
@@ -83,6 +83,6 @@ jobs:
         env:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY || secrets.KIMI_API_KEY }}
-          FLUE_MODEL: ${{ vars.FLUE_MODEL || 'moonshotai/kimi-k2.6' }}
+          FLUE_MODEL: ${{ vars.FLUE_MODEL || 'kimi-coding/kimi-for-coding' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run upstream:takopi -- --target node --id takopi-upstream --payload "$(cat /tmp/upstream-takopi-payload.json)"


### PR DESCRIPTION
## Summary
- change the default Flue model from the Moonshot endpoint to the Kimi Coding provider
- keep using the existing KIMI_API_KEY secret by default

## Verification
- npm run typecheck
- git diff --check

## Context
GitHub dry-run results:
- main reached Flue but failed with missing moonshotai API key before PR #58
- PR #58 branch mapped the secret but then failed with 401 on the Moonshot endpoint
- switching to kimi-coding/kimi-for-coding uses the provider tied to KIMI_API_KEY