### PR TITLE
Adapt Discord transport to Takopi v0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ enabled = false                  # Enable /file + attachment auto-upload
 # auto_put_mode = "upload"       # "upload" (default) or "prompt"
 uploads_dir = "incoming"         # Relative path in the repo
 # max_upload_bytes = 20971520    # 20MB
-# max_download_bytes = 52428800  # 50MB
+# max_download_bytes = 10485760  # 10MB Discord base upload limit; raise for boosted/Nitro-capable servers
 # deny_globs = [".git/**", ".env", ".envrc", "**/*.pem", "**/.ssh/**"]
 # allowed_user_ids = [123456789012345678]  # Optional: restrict file transfers separately
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ enabled = false                  # Enable /file + attachment auto-upload
 # auto_put_mode = "upload"       # "upload" (default) or "prompt"
 uploads_dir = "incoming"         # Relative path in the repo
 # max_upload_bytes = 20971520    # 20MB
+# max_download_bytes = 52428800  # 50MB
 # deny_globs = [".git/**", ".env", ".envrc", "**/*.pem", "**/.ssh/**"]
 # allowed_user_ids = [123456789012345678]  # Optional: restrict file transfers separately
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.14"
 dependencies = [
     "py-cord>=2.6.0",
     "openai>=1.0.0",
-    "takopi>=0.17.0",
+    "takopi>=0.18.0",
     "pywhispercpp>=1.4.0",
 ]
 classifiers = [

--- a/src/takopi_discord/backend.py
+++ b/src/takopi_discord/backend.py
@@ -180,7 +180,7 @@ class DiscordBackend(TransportBackend):
             uploads_dir=files_settings.get("uploads_dir", "incoming"),
             max_upload_bytes=files_settings.get("max_upload_bytes", 20 * 1024 * 1024),
             max_download_bytes=files_settings.get(
-                "max_download_bytes", 50 * 1024 * 1024
+                "max_download_bytes", 10 * 1024 * 1024
             ),
             deny_globs=tuple(
                 files_settings.get(

--- a/src/takopi_discord/backend.py
+++ b/src/takopi_discord/backend.py
@@ -179,6 +179,9 @@ class DiscordBackend(TransportBackend):
             auto_put_mode=files_settings.get("auto_put_mode", "upload"),
             uploads_dir=files_settings.get("uploads_dir", "incoming"),
             max_upload_bytes=files_settings.get("max_upload_bytes", 20 * 1024 * 1024),
+            max_download_bytes=files_settings.get(
+                "max_download_bytes", 50 * 1024 * 1024
+            ),
             deny_globs=tuple(
                 files_settings.get(
                     "deny_globs",

--- a/src/takopi_discord/bridge.py
+++ b/src/takopi_discord/bridge.py
@@ -131,6 +131,7 @@ class DiscordFilesSettings:
     auto_put_mode: Literal["upload", "prompt"] = "upload"
     uploads_dir: str = "incoming"
     max_upload_bytes: int = 20 * 1024 * 1024  # 20MB
+    max_download_bytes: int = 50 * 1024 * 1024  # 50MB
     deny_globs: tuple[str, ...] = (
         ".git/**",
         ".env",

--- a/src/takopi_discord/bridge.py
+++ b/src/takopi_discord/bridge.py
@@ -131,7 +131,7 @@ class DiscordFilesSettings:
     auto_put_mode: Literal["upload", "prompt"] = "upload"
     uploads_dir: str = "incoming"
     max_upload_bytes: int = 20 * 1024 * 1024  # 20MB
-    max_download_bytes: int = 50 * 1024 * 1024  # 50MB
+    max_download_bytes: int = 10 * 1024 * 1024  # 10MB
     deny_globs: tuple[str, ...] = (
         ".git/**",
         ".env",

--- a/src/takopi_discord/commands/dispatch.py
+++ b/src/takopi_discord/commands/dispatch.py
@@ -44,6 +44,7 @@ async def dispatch_command(
     message_id: int,
     guild_id: int | None,
     thread_id: int | None,
+    sender_id: int | None = None,
     reply_ref: MessageRef | None,
     reply_text: str | None,
     running_tasks: RunningTasks,
@@ -76,6 +77,7 @@ async def dispatch_command(
         channel_id=channel_id,
         message_id=message_id,
         thread_id=thread_id,
+        sender_id=sender_id,
     )
 
     try:

--- a/src/takopi_discord/commands/registration.py
+++ b/src/takopi_discord/commands/registration.py
@@ -198,6 +198,7 @@ async def _handle_plugin_command(
             message_id=message_id,
             guild_id=guild_id,
             thread_id=thread_id,
+            sender_id=author_id,
             reply_ref=None,  # Slash commands don't have a message to reply to
             reply_text=None,
             running_tasks=running_tasks,

--- a/src/takopi_discord/file_transfer.py
+++ b/src/takopi_discord/file_transfer.py
@@ -32,9 +32,6 @@ __all__ = [
     "zip_directory",
 ]
 
-# Discord attachment size limit (25MB for non-nitro servers)
-MAX_FILE_SIZE = 25 * 1024 * 1024
-
 # Default deny patterns
 DEFAULT_DENY_GLOBS = (".git/**", "*.env", ".env.*", "**/.env", "**/credentials*")
 

--- a/src/takopi_discord/handlers.py
+++ b/src/takopi_discord/handlers.py
@@ -869,7 +869,6 @@ def register_slash_commands(
         from takopi.context import RunContext
 
         from .file_transfer import (
-            MAX_FILE_SIZE,
             ZipTooLargeError,
             default_upload_name,
             deny_reason,
@@ -1005,11 +1004,11 @@ def register_slash_commands(
                                 project_root,
                                 rel_path,
                                 deny_globs,
-                                max_bytes=MAX_FILE_SIZE,
+                                max_bytes=files.max_download_bytes,
                             )
                         except ZipTooLargeError:
                             await ctx.followup.send(
-                                f"Directory too large to zip (>{format_bytes(MAX_FILE_SIZE)}).",
+                                f"Directory too large to zip (>{format_bytes(files.max_download_bytes)}).",
                                 ephemeral=True,
                             )
                             return
@@ -1026,9 +1025,9 @@ def register_slash_commands(
                     else:
                         # Send file directly
                         size = target.stat().st_size
-                        if size > MAX_FILE_SIZE:
+                        if size > files.max_download_bytes:
                             await ctx.followup.send(
-                                f"File too large ({format_bytes(size)} > {format_bytes(MAX_FILE_SIZE)}).",
+                                f"File too large ({format_bytes(size)} > {format_bytes(files.max_download_bytes)}).",
                                 ephemeral=True,
                             )
                             return

--- a/tests/test_backend_allowed_bot_ids.py
+++ b/tests/test_backend_allowed_bot_ids.py
@@ -50,3 +50,33 @@ def test_build_and_run_parses_allowed_bot_user_ids(tmp_path: Path, monkeypatch) 
     )
 
     assert captured["cfg"].allowed_bot_user_ids == frozenset({123, 456})
+
+
+def test_build_and_run_parses_max_download_bytes(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run_main_loop(cfg, **kwargs) -> None:
+        captured["cfg"] = cfg
+        captured["kwargs"] = kwargs
+
+    def fake_anyio_run(fn) -> None:
+        asyncio.run(fn())
+
+    monkeypatch.setattr(backend_module, "run_main_loop", fake_run_main_loop)
+    monkeypatch.setattr(backend_module.anyio, "run", fake_anyio_run)
+
+    transport_config = {
+        "bot_token": "secret",
+        "files": {"max_download_bytes": 10 * 1024 * 1024},
+        "voice_messages": {},
+    }
+
+    backend_module.DiscordBackend().build_and_run(
+        transport_config=transport_config,
+        config_path=tmp_path / "config.yaml",
+        runtime=_runtime_stub(tmp_path / "config.yaml"),
+        final_notify=False,
+        default_engine_override=None,
+    )
+
+    assert captured["cfg"].files.max_download_bytes == 10 * 1024 * 1024

--- a/tests/test_dispatch_command.py
+++ b/tests/test_dispatch_command.py
@@ -1,0 +1,85 @@
+"""Tests for plugin command dispatch."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from takopi.transport import MessageRef
+from takopi_discord.commands.dispatch import dispatch_command
+
+
+@pytest.mark.anyio
+async def test_dispatch_command_populates_sender_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MessageRef passed to CommandContext should carry sender_id."""
+    cfg = MagicMock()
+    cfg.runtime = MagicMock()
+    cfg.runtime.allowlist = None
+    cfg.runtime.plugin_config.return_value = {}
+    cfg.show_resume_line = True
+    cfg.exec_cfg = MagicMock()
+
+    backend = MagicMock()
+    backend.handle = AsyncMock(return_value=None)
+
+    with patch("takopi_discord.commands.dispatch.get_command", return_value=backend):
+        handled = await dispatch_command(
+            cfg,
+            command_id="hello",
+            args_text="world",
+            full_text="/hello world",
+            channel_id=123,
+            message_id=456,
+            guild_id=789,
+            thread_id=None,
+            sender_id=4242,
+            reply_ref=None,
+            reply_text=None,
+            running_tasks={},
+            on_thread_known=None,
+            default_engine_override=None,
+            engine_overrides_resolver=None,
+        )
+
+    assert handled is True
+    ctx = backend.handle.call_args.args[0]
+    assert isinstance(ctx.message, MessageRef)
+    assert ctx.message.sender_id == 4242
+
+
+@pytest.mark.anyio
+async def test_dispatch_command_sender_id_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MessageRef.sender_id should default to None when not provided."""
+    cfg = MagicMock()
+    cfg.runtime = MagicMock()
+    cfg.runtime.allowlist = None
+    cfg.runtime.plugin_config.return_value = {}
+    cfg.show_resume_line = True
+    cfg.exec_cfg = MagicMock()
+
+    backend = MagicMock()
+    backend.handle = AsyncMock(return_value=None)
+
+    with patch("takopi_discord.commands.dispatch.get_command", return_value=backend):
+        handled = await dispatch_command(
+            cfg,
+            command_id="hello",
+            args_text="world",
+            full_text="/hello world",
+            channel_id=123,
+            message_id=456,
+            guild_id=789,
+            thread_id=None,
+            reply_ref=None,
+            reply_text=None,
+            running_tasks={},
+            on_thread_known=None,
+            default_engine_override=None,
+            engine_overrides_resolver=None,
+        )
+
+    assert handled is True
+    ctx = backend.handle.call_args.args[0]
+    assert isinstance(ctx.message, MessageRef)
+    assert ctx.message.sender_id is None

--- a/tests/test_dispatch_command.py
+++ b/tests/test_dispatch_command.py
@@ -11,7 +11,9 @@ from takopi_discord.commands.dispatch import dispatch_command
 
 
 @pytest.mark.anyio
-async def test_dispatch_command_populates_sender_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_dispatch_command_populates_sender_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """MessageRef passed to CommandContext should carry sender_id."""
     cfg = MagicMock()
     cfg.runtime = MagicMock()
@@ -49,7 +51,9 @@ async def test_dispatch_command_populates_sender_id(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.anyio
-async def test_dispatch_command_sender_id_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_dispatch_command_sender_id_defaults_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """MessageRef.sender_id should default to None when not provided."""
     cfg = MagicMock()
     cfg.runtime = MagicMock()

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -105,6 +105,7 @@ class TestDiscordFilesSettings:
         assert settings.auto_put_mode == "upload"
         assert settings.uploads_dir == "incoming"
         assert settings.max_upload_bytes == 20 * 1024 * 1024
+        assert settings.max_download_bytes == 50 * 1024 * 1024
 
     def test_custom_values(self) -> None:
         settings = DiscordFilesSettings(enabled=True, auto_put_mode="prompt")

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -105,7 +105,7 @@ class TestDiscordFilesSettings:
         assert settings.auto_put_mode == "upload"
         assert settings.uploads_dir == "incoming"
         assert settings.max_upload_bytes == 20 * 1024 * 1024
-        assert settings.max_download_bytes == 50 * 1024 * 1024
+        assert settings.max_download_bytes == 10 * 1024 * 1024
 
     def test_custom_values(self) -> None:
         settings = DiscordFilesSettings(enabled=True, auto_put_mode="prompt")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.14"
 
 [[package]]
@@ -885,7 +885,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0.0" },
     { name = "py-cord", specifier = ">=2.6.0" },
     { name = "pywhispercpp", specifier = ">=1.4.0" },
-    { name = "takopi", specifier = ">=0.17.0" },
+    { name = "takopi", specifier = ">=0.18.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Refs #60

Draft adaptation generated by the upstream Takopi tracking workflow for banteg/takopi v0.17.0...v0.18.0.

The workflow completed analysis, pushed this branch, and passed tests before GitHub blocked PR creation due repository Actions permissions. Permissions have since been updated, so this opens the branch manually.

Verification from workflow run 25940686499:
- 103 tests passed
- ruff check passed